### PR TITLE
Translate 'Getting Started' section into Korean

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/guide-chat.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/guide-chat.mdx
@@ -5,21 +5,21 @@ sidebar_position: 3
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/models/chat/chat_streaming_stdout.ts";
 
-# Quickstart, using Chat Models
+# 빠른 시작, 대화 모델 사용
 
-Chat models are a variation on language models.
-While chat models use language models under the hood, the interface they expose is a bit different.
-Rather than expose a "text in, text out" API, they expose an interface where "chat messages" are the inputs and outputs.
+대화 모델은 언어 모델의 한 종류입니다.
+대화 모델은 내부적으로 언어 모델을 사용하지만, 노출하는 인터페이스는 약간 다릅니다.
+텍스트를 입력 받고 텍스트를 출력하는 API를 제공하는 대신, 입력과 출력이 "채팅 메시지"인 인터페이스를 가지고 있습니다.
 
-Chat model APIs are fairly new, so we are still figuring out the correct abstractions.
+대화 모델 API는 아직 매우 새로운 것이기 때문에, 올바르게 추상화하기 위해 우리는 아직 많은 고민을 하고 있습니다.
 
-## Installation and Setup
+## 설치하기
 
-To get started, follow the [installation instructions](./install) to install LangChain.
+시작하려면, [설치 가이드](./install)를 따라 LangChain을 설치하세요.
 
-## Getting Started
+## 시작하기
 
-This section covers how to get started with chat models. The interface is based around messages rather than raw text.
+이 섹션은 Langchain으로 대화 모델을 다루는 방법을 설명합니다. 인터페이스는 원시 텍스트(raw text)가 아닌 메시지를 기반으로 합니다.
 
 ```typescript
 import { ChatOpenAI } from "langchain/chat_models/openai";
@@ -28,16 +28,16 @@ import { HumanChatMessage, SystemChatMessage } from "langchain/schema";
 const chat = new ChatOpenAI({ temperature: 0 });
 ```
 
-Here we create a chat model using the API key stored in the environment variable `OPENAI_API_KEY`. We'll be calling this chat model throughout this section.
+여기서 우리는 환경 변수 `OPENAI_API_KEY`에 저장된 API 키를 사용하여 대화 모델을 만듭니다. 이 섹션이 진행되는 동안 우리는 이 대화 모델을 계속 호출하게 될 것입니다.
 
-### Chat Models: Message in, Message out
+### 대화 모델: 메시지 입출력
 
-You can get chat completions by passing one or more messages to the chat model. The response will also be a message. The types of messages currently supported in LangChain are `AIChatMessage`, `HumanChatMessage`, `SystemChatMessage`, and a generic `ChatMessage` -- ChatMessage takes in an arbitrary role parameter, which we won't be using here. Most of the time, you'll just be dealing with `HumanChatMessage`, `AIChatMessage`, and `SystemChatMessage`.
+대화 완성(chat completions)을 받기 위해서는, 하나 이상의 메시지를 대화 모델에 전달하면 됩니다. 응답 역시 메시지가 됩니다. 현재 LangChain에서 지원하는 메시지 유형은 `AIChatMessage`, `HumanChatMessage`, `SystemChatMessage`와 일반적인 `ChatMessage`입니다. -- ChatMessage는 임의의 역할(role) 매개 변수를 받습니다. (이 내용에 대해서는 여기서 다루지 않습니다.) 대부분의 경우, `HumanChatMessage`, `AIChatMessage`와 `SystemChatMessage`를 주로 사용하게 될 것입니다.
 
 ```typescript
 const response = await chat.call([
   new HumanChatMessage(
-    "Translate this sentence from English to French. I love programming."
+    "Translate this sentence from English to Korean. I love programming."
   ),
 ]);
 
@@ -45,17 +45,17 @@ console.log(response);
 ```
 
 ```
-AIChatMessage { text: "J'aime programmer." }
+AIChatMessage { text: "저는 프로그래밍을 사랑합니다." }
 ```
 
-#### Multiple Messages
+#### 여러 개의 메시지
 
-OpenAI's chat-based models (currently `gpt-3.5-turbo` and `gpt-4`) support multiple messages as input. See [here](https://platform.openai.com/docs/guides/chat/chat-vs-completions) for more information. Here is an example of sending a system and user message to the chat model:
+OpenAI의 채팅 기반 모델(현재 `gpt-3.5-turbo`와 `gpt-4`)은 입력으로 여러 메시지를 지원합니다. 자세한 내용은 [여기](https://platform.openai.com/docs/guides/chat/chat-vs-completions)를 참고하세요. 여기서는 시스템(system)과 사용자(user) 메시지를 채팅 모델에 보내는 예제를 보여줍니다.
 
 ```typescript
 response = await chat.call([
   new SystemChatMessage(
-    "You are a helpful assistant that translates English to French."
+    "You are a helpful assistant that translates English to Korean."
   ),
   new HumanChatMessage("Translate: I love programming."),
 ]);
@@ -64,29 +64,29 @@ console.log(response);
 ```
 
 ```
-AIChatMessage { text: "J'aime programmer." }
+AIChatMessage { text: "저는 프로그래밍을 사랑합니다." }
 ```
 
-#### Multiple Completions
+#### 여러 개의 완성(Completions)
 
-You can go one step further and generate completions for multiple sets of messages using generate. This returns an LLMResult with an additional message parameter.
+`generate`를 사용하여 여러 메시지 셋에 대한 완성(completion)을 생성할 수 있습니다. 이렇게 하면 메시지 매개변수가 추가된 LLMResult가 반환됩니다.
 
 ```typescript
 const responseC = await chat.generate([
   [
     new SystemChatMessage(
-      "You are a helpful assistant that translates English to French."
+      "You are a helpful assistant that translates English to Korean."
     ),
     new HumanChatMessage(
-      "Translate this sentence from English to French. I love programming."
+      "Translate this sentence from English to Korean. I love programming."
     ),
   ],
   [
     new SystemChatMessage(
-      "You are a helpful assistant that translates English to French."
+      "You are a helpful assistant that translates English to Korean."
     ),
     new HumanChatMessage(
-      "Translate this sentence from English to French. I love artificial intelligence."
+      "Translate this sentence from English to Korean. I love artificial intelligence."
     ),
   ],
 ]);
@@ -99,25 +99,25 @@ console.log(responseC);
   generations: [
     [
       {
-        text: "J'aime programmer.",
-        message: AIChatMessage { text: "J'aime programmer." },
+        text: "저는 프로그래밍을 사랑합니다.",
+        message: AIChatMessage { text: "저는 프로그래밍을 사랑합니다." },
       }
     ],
     [
       {
-        text: "J'aime l'intelligence artificielle.",
-        message: AIChatMessage { text: "J'aime l'intelligence artificielle." }
+        text: "저는 인공지능을 사랑합니다.",
+        message: AIChatMessage { text: "저는 인공지능을 사랑합니다." }
       }
     ]
   ]
 }
 ```
 
-### Chat Prompt Templates: Manage Prompts for Chat Models
+### 대화 프롬프트 템플릿: 대화 모델을 위한 프롬프트 관리
 
-You can make use of templating by using a `MessagePromptTemplate`. You can build a `ChatPromptTemplate` from one or more `MessagePromptTemplates`. You can use `ChatPromptTemplate`'s `formatPromptValue` -- this returns a `PromptValue`, which you can convert to a string or Message object, depending on whether you want to use the formatted value as input to an llm or chat model.
+`MessagePromptTemplate`을 활용하면 템플릿을 만들 수 있습니다. 하나 이상의 `MessagePromptTemplate`을 묶어 `ChatPromptTemplate`으로 구성할 수도 있습니다. `ChatPromptTemplate`의 `formatPromptValue`를 사용하면 `PromptValue`가 반환되는데, 입력값을 언어 모델 또는 채팅 모델로 중 어느 것으로 사용하고자 하는지에 따라 문자열이나 메시지 객체로 변환해 사용할 수 있습니다.
 
-Continuing with the previous example:
+이전 예시에 이어서 진행합니다.
 
 ```typescript
 import {
@@ -127,7 +127,7 @@ import {
 } from "langchain/prompts";
 ```
 
-First we create a reusable template:
+가장 먼저, 재사용 가능한 템플릿을 만듭니다.
 
 ```typescript
 const translationPrompt = ChatPromptTemplate.fromPromptMessages([
@@ -138,13 +138,13 @@ const translationPrompt = ChatPromptTemplate.fromPromptMessages([
 ]);
 ```
 
-Then we can use the template to generate a response:
+그 후에 템플릿을 사용하여 응답을 생성합니다.
 
 ```typescript
 const responseA = await chat.generatePrompt([
   await translationPrompt.formatPromptValue({
     input_language: "English",
-    output_language: "French",
+    output_language: "Korean",
     text: "I love programming.",
   }),
 ]);
@@ -157,17 +157,17 @@ console.log(responseA);
   generations: [
     [
       {
-        text: "J'aime programmer.",
-        message: AIChatMessage { text: "J'aime programmer." }
+        text: "저는 프로그래밍을 사랑합니다.",
+        message: AIChatMessage { text: "저는 프로그래밍을 사랑합니다." }
       }
     ]
   ]
 }
 ```
 
-### Model + Prompt = LLMChain
+### 모델 + 프롬프트 = LLMChain
 
-This pattern of asking for the completion of a formatted prompt is quite common, so we introduce the next piece of the puzzle: LLMChain
+프롬프트로 대화 완성(completion)을 요청하는 경우는 매우 많으므로, LLMChain을 통해 간결하게 구현할 수 있도록 해두었습니다.
 
 ```typescript
 const chain = new LLMChain({
@@ -176,12 +176,12 @@ const chain = new LLMChain({
 });
 ```
 
-Then you can call the chain:
+그 후에 바로 체인을 호출하면 됩니다.
 
 ```typescript
 const responseB = await chain.call({
   input_language: "English",
-  output_language: "French",
+  output_language: "Korean",
   text: "I love programming.",
 });
 
@@ -189,10 +189,10 @@ console.log(responseB);
 ```
 
 ```
-{ text: "J'aime programmer." }
+{ text: "저는 프로그래밍을 사랑합니다." }
 ```
 
-The chain will internally accumulate the messages sent to the model, and the ones received as output. Then it will inject the messages into the prompt on the next call. So you can call the chain a few times, and it remembers previous messages:
+체인은 내부적으로 모델에 보내진 메시지와 출력된 메시지를 누적시켜놓고, 다음 호출 시 프롬프트에 메시지를 주입합니다. 따라서 체인을 여러 번 호출하면 이전 메시지를 기억합니다.
 
 ```typescript
 const responseD = await chain.call({
@@ -220,11 +220,11 @@ console.log(responseE);
 }
 ```
 
-### Agents: Dynamically Run Chains Based on User Input
+### 에이전트: 사용자 입력에 따라 동적으로 체인 실행하기
 
-Finally, we introduce Tools and Agents, which extend the model with other abilities, such as search, or a calculator.
+이제 드디어 검색 또는 계산기와 같은 다른 기능을 추가하여 모델을 확장하는 도구와 에이전트를 소개합니다.
 
-A tool is a function that takes a string (such as a search query) and returns a string (such as a search result). They also have a name and description, which are used by the chat model to identify which tool it should call.
+도구(Tool)는 문자열(예: 검색 쿼리)을 입력으로 받아 문자열(예: 검색 결과)을 반환하는 함수입니다. 또한 `name`과 `description`을 가지고 있는데, 채팅 모델이 어떤 도구를 호출해야 하는지 식별하는 데 사용됩니다.
 
 ```typescript
 class Tool {
@@ -234,7 +234,7 @@ class Tool {
 }
 ```
 
-An agent is a stateless wrapper around an agent prompt chain (such as MRKL) which takes care of formatting tools into the prompt, as well as parsing the responses obtained from the chat model.
+에이전트는 에이전트 프롬프트 체인(예: MRKL)을 상태 관리 없이 감싸는 래퍼(wrapper)로, 도구를 프롬프트로 포맷하고 채팅 모델로부터 얻은 응답을 파싱하는 작업을 처리합니다.
 
 ```typescript
 interface AgentStep {
@@ -256,7 +256,7 @@ class Agent {
 }
 ```
 
-To make agents more powerful we need to make them iterative, ie. call the model multiple times until they arrive at the final answer. That's the job of the AgentExecutor.
+에이전트를 더 강력하게 만들기 위해서는, 최종 답변에 도달할 때까지 모델을 여러 번 호출해야 합니다. 이것이 AgentExecutor의 역할입니다.
 
 ```typescript
 class AgentExecutor {
@@ -274,7 +274,7 @@ class AgentExecutor {
 }
 ```
 
-And finally, we can use the AgentExecutor to run an agent:
+그리고 마지막으로, AgentExecutor를 사용하여 에이전트를 실행할 수 있습니다.
 
 ```typescript
 // Define the list of tools the agent can use
@@ -301,9 +301,9 @@ console.log(responseG);
 38,626,704.
 ```
 
-### Memory: Add State to Chains and Agents
+### 메모리: 체인과 에이전트에 상태 추가하기
 
-You can also use the chain to store state. This is useful for eg. chatbots, where you want to keep track of the conversation history. MessagesPlaceholder is a special prompt template that will be replaced with the messages passed in each call.
+체인을 사용하여 상태를 저장할 수도 있습니다. 챗봇이 대화 내용을 기억하게 하고 싶은 경우에 유용하게 사용할 수 있습니다. MessagesPlaceholder는 각 호출에 전달된 메시지로 대체될 특수한 프롬프트 템플릿입니다.
 
 ```typescript
 const chatPrompt = ChatPromptTemplate.fromPromptMessages([
@@ -323,6 +323,6 @@ const chain = new ConversationChain({
 
 ## Streaming
 
-You can also use the streaming API to get words streamed back to you as they are generated. This is useful for eg. chatbots, where you want to show the user what is being generated as it is being generated. Note: OpenAI as of this writing does not support `tokenUsage` reporting while streaming is enabled.
+스트리밍 API를 사용하여 각 단어가 생성될 때마다 단어를 실시간 스트림으로 받을 수도 있습니다. 예를 들어 채팅봇에서 사용자에게 생성되는 내용을 생성되는 즉시 보여주고자 할 때 유용하게 사용할 수 있습니다. 참고로, 이 문서를 작성하는 시점에는 스트리밍 옵션이 활성화되면 OpenAI에서 `tokenUsage`를 지원하지 않습니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/guide-llm.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/guide-llm.mdx
@@ -5,57 +5,57 @@ sidebar_position: 2
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/models/llm/llm_streaming_stdout.ts";
 
-# Quickstart, using LLMs
+# 빠른 시작, LLM 사용
 
-This tutorial gives you a quick walkthrough about building an end-to-end language model application with LangChain.
+이 튜토리얼은 LangChain을 사용하여 end-to-end 언어 모델 애플리케이션을 구축하는 방법에 대한 빠른 안내서를 제공합니다.
 
-## Installation and Setup
+## 초기 세팅과 설치
 
-To get started, follow the [installation instructions](./install) to install LangChain.
+시작하려면, [설치 가이드](./install)을 참고해 LangChain을 설치하세요.
 
-## Picking up a LLM
+## LLM 선택하기
 
-Using LangChain will usually require integrations with one or more model providers, data stores, apis, etc.
+LangChain을 사용하면 대개 하나 이상의 모델 제공자, 데이터 저장소, API 등과 통합이 필요합니다.
 
-For this example, we will be using OpenAI's APIs, so no additional setup is required.
+이 예제에서는 OpenAI의 API를 사용하므로 추가 설정이 필요하지 않습니다.
 
-## Building a Language Model Application
+## 언어 모델 애플리케이션 구축하기
 
-Now that we have installed LangChain, we can start building our language model application.
+LangChain을 설치했다면, 이제 언어 모델 애플리케이션을 구축할 수 있습니다.
 
-LangChain provides many modules that can be used to build language model applications. Modules can be combined to create more complex applications, or be used individually for simple applications.
+LangChain은 언어 모델 애플리케이션을 구축하는 데 사용할 수 있는 많은 모듈을 제공합니다. 모듈은 더 복잡한 애플리케이션을 만들기 위해 결합되거나, 간단한 애플리케이션에 대해 개별적으로 사용될 수 있습니다.
 
-### LLMs: Get Predictions from a Language Model
+### LLMs: 언어모델로부터 예측 결과 얻기
 
-The most basic building block of LangChain is calling an LLM on some input. Let's walk through a simple example of how to do this. For this purpose, let's pretend we are building a service that generates a company name based on what the company makes.
+LangChain의 가장 기본적인 구성 요소는 입력값에 대해 LLM을 호출하는 것입니다. 간단한 예제를 살펴보겠습니다. 이를 위해 우리는 회사가 제작하는 제품을 기반으로 회사 이름을 생성하는 서비스를 구축하고 있다고 가정해봅시다.
 
-In order to do this, we first need to import the LLM wrapper.
+가장 먼저 LLM 래퍼(wrapper)를 가져와야 합니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
 ```
 
-We will then need to set the environment variable for the OpenAI key. Three options here:
+그런 다음 OpenAI 키에 대한 환경 변수를 설정해야 합니다. 세 가지 옵션이 있습니다.
 
-1. We can do this by setting the value in a `.env` file and use the [dotenv](https://github.com/motdotla/dotenv) package to read it.
+1. `.env` 파일에 값을 설정하고 [dotenv](https://github.com/motdotla/dotenv) 패키지를 사용하여 읽을 수 있습니다.
 
 ```bash
 OPENAI_API_KEY="..."
 ```
 
-2. Or we can export the environment variable with the following command in your shell:
+2. 또는 shell에서 다음 명령을 사용하여 환경 변수를 설정할 수 있습니다.
 
 ```bash
 export OPENAI_API_KEY=sk-....
 ```
 
-3. Or we can do it when initializing the wrapper along with other arguments. In this example, we probably want the outputs to be MORE random, so we'll initialize it with a HIGH temperature.
+3. 또는 래퍼를 초기화할 때 다른 인자와 함께 설정해줘도 됩니다. 이 예시에서는 출력이 더 무작위적이기를 원하므로 높은 `temperature` 값으로 초기화하겠습니다.
 
 ```typescript
 const model = new OpenAI({ openAIApiKey: "sk-...", temperature: 0.9 });
 ```
 
-Once we have initialized the wrapper, we can now call it on some input!
+래퍼를 초기화했다면, 이제 입력값을 넣어 호출해 볼 수 있습니다!
 
 ```typescript
 const res = await model.call(
@@ -68,15 +68,15 @@ console.log(res);
 { res: '\n\nFantasy Sockery' }
 ```
 
-### Prompt Templates: Manage Prompts for LLMs
+### 프롬프트 템플릿: LLM 프롬프트 관리
 
-Calling an LLM is a great first step, but it's just the beginning. Normally when you use an LLM in an application, you are not sending user input directly to the LLM. Instead, you are probably taking user input and constructing a prompt, and then sending that to the LLM.
+LLM을 호출하는 것은 좋은 첫 단계이지만, 시작에 불과합니다. 일반적으로 애플리케이션에서 LLM을 사용할 때 사용자 입력을 LLM에 직접 전송하지 않습니다. 대신 사용자 입력을 가져와 프롬프트를 구성한 다음 LLM에 전송하게 될 것입니다.
 
-For example, in the previous example, the text we passed in was hardcoded to ask for a name for a company that made colorful socks. In this imaginary service, what we would want to do is take only the user input describing what the company does, and then format the prompt with that information.
+예를 들어, 이전 예제에서는 컬러풀한 양말을 만드는 회사의 이름을 요청하는 하드코딩된 텍스트를 전달했습니다. 이제 이것을 회사가 무엇을 하는지 설명하는 사용자 입력을 받아 그 정보로 프롬프트를 만든 후 전달하도록 수정해보겠습니다.
 
-This is easy to do with LangChain!
+LangChain을 사용하면 쉽게 할 수 있습니다!
 
-First lets define the prompt template:
+먼저 프롬프트 템플릿을 정의합시다.
 
 ```typescript
 import { PromptTemplate } from "langchain/prompts";
@@ -88,7 +88,7 @@ const prompt = new PromptTemplate({
 });
 ```
 
-Let's now see how this works! We can call the `.format` method to format it.
+이제 어떻게 작동하는지 살펴보겠습니다! `.format` 메서드를 호출하여 형식을 지정할 수 있습니다.
 
 ```typescript
 const res = await prompt.format({ product: "colorful socks" });
@@ -99,15 +99,15 @@ console.log(res);
 { res: 'What is a good name for a company that makes colorful socks?' }
 ```
 
-### Chains: Combine LLMs and Prompts in Multi-Step Workflows
+### 체인: 다단계 워크플로우에서 LLM과 프롬프트 결합하기
 
-Up until now, we've worked with the PromptTemplate and LLM primitives by themselves. But of course, a real application is not just one primitive, but rather a combination of them.
+지금까지 PromptTemplate과 LLM 기본 요소를 각각 사용해봤습니다. 하지만 실제 애플리케이션은 이렇게 하나의 기본 요소가 아니라 여러 요소들의 조합으로 이뤄집니다.
 
-A chain in LangChain is made up of links, which can be either primitives like LLMs or other chains.
+LangChain에서 체인은 LLM과 같은 기본 요소나 다른 체인들로이 링크처럼 구성되어 있는 형태입니다.
 
-The most core type of chain is an LLMChain, which consists of a PromptTemplate and an LLM.
+가장 핵심적인 체인 타입은 LLMChain으로, 이는 PromptTemplate과 LLM으로 구성됩니다.
 
-Extending the previous example, we can construct an LLMChain which takes user input, formats it with a PromptTemplate, and then passes the formatted response to an LLM.
+이전 예제를 확장하여, 사용자 입력을 받아 PromptTemplate으로 형식을 지정한 후 그 프롬프트를 LLM에 전달하는 LLMChain을 구성해보겠습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -121,7 +121,7 @@ const prompt = new PromptTemplate({
 });
 ```
 
-We can now create a very simple chain that will take user input, format the prompt with it, and then send it to the LLM:
+사용자 입력을 받아 프롬프트로 형식을 지정한 다음 LLM으로 전송하는 매우 간단한 체인을 만들어 봅시다.
 
 ```typescript
 import { LLMChain } from "langchain/chains";
@@ -129,7 +129,7 @@ import { LLMChain } from "langchain/chains";
 const chain = new LLMChain({ llm: model, prompt: prompt });
 ```
 
-Now we can run that chain only specifying the product!
+이제 제품이 뭔지만 입력해주면 이 체인을 실행할 수 있습니다!
 
 ```typescript
 const res = await chain.call({ product: "colorful socks" });
@@ -140,35 +140,35 @@ console.log(res);
 { res: { text: '\n\nColorfulCo Sockery.' } }
 ```
 
-There we go! There's the first chain - an LLM Chain. This is one of the simpler types of chains, but understanding how it works will set you up well for working with more complex chains.
+다 됐습니다! 우리는 첫 번째 체인으로 LLM 체인을 만들어봤습니다. LLM 체인은 간단한 편에 속하지만, 분명 더 복잡한 체인을 이해하는 데에 도움이 될 것입니다.
 
-### Agents: Dynamically Run Chains Based on User Input
+### 에이전트: 사용자 입력에 기반하여 동적으로 체인 실행하기
 
-So far the chains we've looked at run in a predetermined order.
+지금까지 살펴본 체인은 우리가 미리 결정해 놓은 순서로 실행됩니다.
 
-Agents no longer do: they use an LLM to determine which actions to take and in what order. An action can either be using a tool and observing its output, or returning to the user.
+하지만, 에이전트를 사용하면 더 이상 그렇게 할 필요가 없습니다. 에이전트는 어떤 작업을 수행하고 어떤 순서로 할지를 결정하기 위해 LLM을 사용합니다. 이 에이전트가 취할 수 있는 액션은 도구를 사용하고 그 결과를 관찰하거나, 혹은 사용자에게 결괏값을 돌려주는 것입니다.
 
-When used correctly agents can be extremely powerful. In this tutorial, we show you how to easily use agents through the simplest, highest level API.
+올바르게만 사용된다면 에이전트는 매우 강력할 수 있습니다. 이 튜토리얼에서는 가장 간단하지만 높은 수준의 API를 통해 에이전트를 쉽게 사용하는 방법을 보여줍니다.
 
-In order to load agents, you should understand the following concepts:
+에이전트를 로드하려면 다음 개념을 이해해야 합니다.
 
-- Tool: A function that performs a specific duty. This can be things like: Google Search, Database lookup, code REPL, other chains. The interface for a tool is currently a function that is expected to have a string as an input, with a string as an output.
-- LLM: The language model powering the agent.
-- Agent: The agent to use. This should be a string that references a support agent class. Because this tutorial focuses on the simplest, highest level API, this only covers using the standard supported agents.
+- 도구(Tool): 특정 업무를 수행하는 함수입니다. Google 검색, 데이터베이스 조회, 코드 REPL, 다른 체인 등이 있을 수 있습니다. 도구의 인터페이스는 현재 string을 입력으로 받아 string을 출력하는 함수입니다.
+- LLM: 에이전트를 구동하는 언어 모델입니다.
+- 에이전트(Agent): 사용할 에이전트입니다. 이는 특정 에이전트 클래스를 참조하는 string이어야 합니다. 이 튜토리얼은 가장 간단하지만 높은 수준의 API에 중점을 두고 있으므로 기본적인 에이전트만 다룹니다.
 
-For this example, you'll need to set the SerpAPI environment variables in the `.env` file.
+이 예제를 따라하기 위해서는 `.env` 파일에 SerpAPI 환경 변수를 설정해야 합니다.
 
 ```bash
 SERPAPI_API_KEY="..."
 ```
 
-Install `serpapi` package (Google Search API):
+`serpapi` 패키지를 설치합니다. (Google Search API)
 
 ```bash npm2yarn
 npm install -S serpapi
 ```
 
-Now we can get started!
+이제 본격적으로 시작해보겠습니다!
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -206,13 +206,13 @@ langchain-examples:start: Executing with input "Who is Olivia Wilde's boyfriend?
 langchain-examples:start: Got output Olivia Wilde's boyfriend is Jason Sudeikis, and his current age raised to the 0.23 power is 2.4242784855673896.
 ```
 
-### Memory: Add State to Chains and Agents
+### 메모리: 체인과 에이전트에 상태 추가하기
 
-So far, all the chains and agents we've gone through have been stateless. But often, you may want a chain or agent to have some concept of "memory" so that it may remember information about its previous interactions. The clearest and simple example of this is when designing a chatbot - you want it to remember previous messages so it can use context from that to have a better conversation. This would be a type of "short-term memory". On the more complex side, you could imagine a chain/agent remembering key pieces of information over time - this would be a form of "long-term memory".
+지금까지 살펴본 모든 체인과 에이전트에는 상태가 없습니다. 그러나 종종 체인이나 에이전트에 이전 상호작용에 대한 정보를 기억하는 "메모리" 개념이 필요할 수 있습니다. 가장 명확하고 간단한 예로, 채팅봇을 설계할 때 이전 메시지를 기억하여 더 나은 대화를 나눌 수 있도록 그 맥락을 사용하고 싶을 수 있습니다. 이것은 "단기 메모리"의 한 형태입니다. 더 복잡하게는 체인/에이전트가 시간이 지남에 따라 중요한 정보를 기억하는 것을 상상해 볼 수도 있습니다. 이것은 "장기 메모리"의 한 형태가 될 것입니다.
 
-LangChain provides several specially created chains just for this purpose. This section walks through using one of those chains (the `ConversationChain`).
+LangChain은 이를 위해 특별히 만들어진 여러 체인을 제공합니다. 이 섹션에서는 그러한 체인 중 하나인 `ConversationChain`을 사용하는 방법에 대해 알아봅니다.
 
-By default, the `ConversationChain` has a simple type of memory that remembers all previous inputs/outputs and adds them to the context that is passed. Let's take a look at using this chain.
+기본적으로 `ConversationChain`은 이전 입/출력을 모두 기억하고 맥락에 추가하는 간단한 유형의 메모리를 가지고 있습니다. 이 체인을 사용하는 방법을 살펴보겠습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -239,8 +239,8 @@ console.log(res2);
 {response: ' You said your name is Jim. Is there anything else you would like to talk about?'}
 ```
 
-## Streaming
+## 스트리밍
 
-You can also use the streaming API to get words streamed back to you as they are generated. This is useful for eg. chatbots, where you want to show the user what is being generated as it is being generated. Note: OpenAI as of this writing does not support `tokenUsage` reporting while streaming is enabled.
+스트리밍 API를 사용하여 각 단어가 생성될 때마다 단어를 실시간 스트림으로 받을 수도 있습니다. 예를 들어 채팅봇에서 사용자에게 생성되는 내용을 생성되는 즉시 보여주고자 할 때 유용하게 사용할 수 있습니다. 참고로, 이 문서를 작성하는 시점에는 스트리밍 옵션이 활성화되면 OpenAI에서 `tokenUsage`를 지원하지 않습니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/install.md
@@ -2,15 +2,15 @@
 sidebar_position: 1
 ---
 
-# Setup and Installation
+# 초기 세팅과 설치
 
 :::info
-Updating from <0.0.52? See [this section](#updating-from-0052) for instructions.
+0.0.52 이하 버전에서 업데이트 하고 계신가요? [이 섹션](#updating-from-0052)을 참고하세요.
 :::
 
-## Supported Environments
+## 지원 환경
 
-LangChain is written in TypeScript and can be used in:
+LangChain은 TypeScript로 작성되었으며 다음 환경에서 사용할 수 있습니다.
 
 - Node.js (ESM and CommonJS) - 18.x, 19.x, 20.x
 - Cloudflare Workers
@@ -19,15 +19,15 @@ LangChain is written in TypeScript and can be used in:
 - Browser
 - Deno
 
-## Quickstart
+## 빠른 시작
 
-If you want to get started quickly on using LangChain in Node.js, [clone this repository](https://github.com/domeccleston/langchain-ts-starter) and follow the README instructions for a boilerplate project with those dependencies set up.
+Node.js에서 LangChain을 빠르게 사용해보고 싶다면, [이 저장소](https://github.com/domeccleston/langchain-ts-starter)를 클론하고 README에 따라 프로젝트를 설정하세요.
 
-If you prefer to set things up yourself, or you want to run LangChain in other environments, read on for instructions.
+직접 설정하거나 다른 환경에서 LangChain을 실행하려는 경우, 아래 설명을 읽어보세요.
 
-## Installation
+## 설치
 
-To get started, install LangChain with the following command:
+시작하려면, 다음 명령어로 LangChain을 설치하세요.
 
 ```bash npm2yarn
 npm install -S langchain
@@ -35,19 +35,19 @@ npm install -S langchain
 
 ### TypeScript
 
-LangChain is written in TypeScript and provides type definitions for all of its public APIs.
+LangChain은 TypeScript로 작성되었으며, 모든 퍼블릭 API에 대한 타입 정의를 제공합니다.
 
-## Loading the library
+## 라이브러리 로딩
 
 ### ESM
 
-LangChain provides an ESM build targeting Node.js environments. You can import it using the following syntax:
+LangChain은 Node.js 환경을 대상으로 ESM 빌드를 제공합니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
 ```
 
-If you are using TypeScript in an ESM project we suggest updating your `tsconfig.json` to include the following:
+ESM 프로젝트에서 TypeScript를 사용하는 경우, 다음을 포함하여 `tsconfig.json`을 업데이트하는 것이 좋습니다.
 
 ```json title="tsconfig.json"
 {
@@ -61,7 +61,7 @@ If you are using TypeScript in an ESM project we suggest updating your `tsconfig
 
 ### CommonJS
 
-LangChain provides a CommonJS build targeting Node.js environments. You can import it using the following syntax:
+LangChain은 Node.js의 CommonJS 빌드를 제공합니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 const { OpenAI } = require("langchain/llms/openai");
@@ -69,7 +69,7 @@ const { OpenAI } = require("langchain/llms/openai");
 
 ### Cloudflare Workers
 
-LangChain can be used in Cloudflare Workers. You can import it using the following syntax:
+LangChain은 Cloudflare Workers에서 사용할 수 있습니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -77,13 +77,14 @@ import { OpenAI } from "langchain/llms/openai";
 
 ### Vercel / Next.js
 
-LangChain can be used in Vercel / Next.js. We support using LangChain in frontend components, in Serverless functions and in Edge functions. You can import it using the following syntax:
+LangChain은 Vercel / Next.js에서 사용할 수 있습니다. LangChain을 프론트엔드 컴포넌트, 서버리스 함수, Edge 함수에서 사용할 수 있습니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
 ```
 
-If you want to use LangChain in frontend `pages`, you need to add the following to your `next.config.js` to enable support for WebAssembly modules (which is required by the tokenizer library `@dqbd/tiktoken`):
+프론트엔드 `pages`에서 LangChain을 사용하려면, 토크나이저 라이브러리인 `@dqbd/tiktoken`가 필요로 하는 WebAssembly 모듈을 지원하도록 다음을 `next.config.js`에 추가해야 합니다.
+
 
 ```js title="next.config.js"
 const nextConfig = {
@@ -100,17 +101,17 @@ const nextConfig = {
 
 ### Deno / Supabase Edge Functions
 
-LangChain can be used in Deno / Supabase Edge Functions. You can import it using the following syntax:
+LangChain은 Deno / Supabase Edge Functions에서 사용할 수 있습니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 import { OpenAI } from "https://esm.sh/langchain/llms/openai";
 ```
 
-We recommend looking at our [Supabase Template](https://github.com/langchain-ai/langchain-template-supabase) for an example of how to use LangChain in Supabase Edge Functions.
+LangChain을 Supabase Edge Functions에서 사용하는 방법에 대한 예제는 [Supabase Template](https://github.com/langchain-ai/langchain-template-supabase)를 참고하세요.
 
 ### Browser
 
-LangChain can be used in the browser. In our CI we test bundling LangChain with Webpack and Vite, but other bundlers should work too. You can import it using the following syntax:
+LangChain은 브라우저에서 사용할 수 있습니다. CI에서는 Webpack과 Vite로 LangChain을 번들링하고 있지만, 다른 번들러도 작동할 것입니다. 다음 구문을 사용하여 가져올 수 있습니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -118,11 +119,11 @@ import { OpenAI } from "langchain/llms/openai";
 
 #### Create React App
 
-If you're using `create-react-app` by default it doesn't support WebAssembly modules, so the tokenizer library `@dqbd/tiktoken` will not work in the browser. You can follow the instructions [here](https://github.com/dqbd/tiktoken/tree/main/js#create-react-app) to enable support for WebAssembly modules.
+만약 `create-react-app`을 사용하고 있다면, 기본적으로 WebAssembly 모듈을 지원하지 않기 때문에 토크나이저 라이브러리인 `@dqbd/tiktoken`이 브라우저에서 작동하지 않습니다. WebAssembly 모듈을 지원하도록 하려면 [여기](https://github.com/dqbd/tiktoken/tree/main/js#create-react-app) 설명을 참고하세요.
 
 #### Vite
 
-If you're using Vite, you need to add the following to your `vite.config.js` to enable support for WebAssembly modules (which is required by the tokenizer library `@dqbd/tiktoken`):
+Vite를 사용하는 경우, WebAssembly 모듈을 지원하도록 다음을 `vite.config.js`에 추가해야 합니다. (토크나이저 라이브러리인 `@dqbd/tiktoken`이 필요로 합니다.)
 
 ```bash npm2yarn
 npm install -D vite-plugin-wasm vite-plugin-top-level-await
@@ -140,53 +141,53 @@ export default defineConfig({
 
 ## Updating from <0.0.52
 
-If you are updating from a version of LangChain prior to 0.0.52, you will need to update your imports to use the new path structure.
+만약 0.0.52 이전 버전의 LangChain을 업데이트하려면, 새로운 경로 구조를 사용하도록 import를 업데이트해야 합니다.
 
-For example, if you were previously doing
+예를 들면, 이전에 이렇게 사용했다면,
 
 ```typescript
 import { OpenAI } from "langchain/llms";
 ```
 
-you will now need to do
+이렇게 바꿔주어야 합니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
 ```
 
-This applies to all imports from the following 6 modules, which have been split into submodules for each integration. The combined modules are deprecated, do not work outside of Node.js, and will be removed in a future version.
+이는 각 통합에 대한 하위 모듈로 분리된 다음 6개 모듈에 적용됩니다. 이전 모듈은 사용이 중지되었으며, Node.js 외부에서 작동하지 않습니다. 향후 버전에서 제거될 예정입니다.
 
-- If you were using `langchain/llms`, see [LLMs](../modules/models/llms/integrations) for updated import paths.
-- If you were using `langchain/chat_models`, see [Chat Models](../modules/models/chat/integrations) for updated import paths.
-- If you were using `langchain/embeddings`, see [Embeddings](../modules/models/embeddings/integrations) for updated import paths.
-- If you were using `langchain/vectorstores`, see [Vector Stores](../modules/indexes/vector_stores/integrations/) for updated import paths.
-- If you were using `langchain/document_loaders`, see [Document Loaders](../modules/indexes/document_loaders/examples/) for updated import paths.
-- If you were using `langchain/retrievers`, see [Retrievers](../modules/indexes/retrievers/) for updated import paths.
+- `langchain/llms`을 사용하고 있다면, [대규모 언어 모델(LLM)](../modules/models/llms/integrations)에서 업데이트 된 import 경로를 찾을 수 있습니다.
+- `langchain/chat_models`을 사용하고 있다면, [채팅 모델](../modules/models/chat/integrations)에서 업데이트 된 import 경로를 찾을 수 있습니다.
+- `langchain/embeddings`을 사용하고 있다면, [임베딩](../modules/models/embeddings/integrations)에서 업데이트 된 import 경로를 찾을 수 있습니다.
+- `langchain/vectorstores`을 사용하고 있다면, [벡터 저장소](../modules/indexes/vector_stores/integrations/)에서 업데이트 된 import 경로를 찾을 수 있습니다.
+- `langchain/document_loaders`을 사용하고 있다면, [문서 로더](../modules/indexes/document_loaders/examples/)에서 업데이트 된 import 경로를 찾을 수 있습니다.
+- `langchain/retrievers`을 사용하고 있다면, [리트리버](../modules/indexes/retrievers/)에서 업데이트 된 import 경로를 찾을 수 있습니다.
 
-Other modules are not affected by this change, and you can continue to import them from the same path.
+다른 모듈은 영향을 받지 않으며, 이전과 동일한 경로에서 가져올 수 있습니다.
 
-Additionally, there are some breaking changes that were needed to support new environments:
+추가로, 새로운 환경을 지원하기 위해 필요한 몇 가지 변경 사항이 있습니다.
 
-- `import { Calculator } from "langchain/tools";` now moved to
-  - `import { Calculator } from "langchain/tools/calculator";`
-- `import { loadLLM } from "langchain/llms";` now moved to
-  - `import { loadLLM } from "langchain/llms/load";`
-- `import { loadAgent } from "langchain/agents";` now moved to
-  - `import { loadAgent } from "langchain/agents/load";`
-- `import { loadPrompt } from "langchain/prompts";` now moved to
-  - `import { loadPrompt } from "langchain/prompts/load";`
-- `import { loadChain } from "langchain/chains";` now moved to
-  - `import { loadChain } from "langchain/chains/load";`
+- `import { Calculator } from "langchain/tools";`은 이제
+  - `import { Calculator } from "langchain/tools/calculator";`로 이동되었습니다.
+- `import { loadLLM } from "langchain/llms";`은 이제
+  - `import { loadLLM } from "langchain/llms/load";`로 이동되었습니다.
+- `import { loadAgent } from "langchain/agents";`은 이제
+  - `import { loadAgent } from "langchain/agents/load";`로 이동되었습니다.
+- `import { loadPrompt } from "langchain/prompts";`은 이제
+  - `import { loadPrompt } from "langchain/prompts/load";`로 이동되었습니다.
+- `import { loadChain } from "langchain/chains";`은 이제
+  - `import { loadChain } from "langchain/chains/load";`로 이동되었습니다.
 
 ## Unsupported: Node.js 16
 
-We do not support Node.js 16, but if you still want to run LangChain on Node.js 16, you will need to follow the instructions in this section. We do not guarantee that these instructions will continue to work in the future.
+우리는 Node.js 16을 지원하지 않지만, 그럼에도 Node.js 16에서 LangChain을 실행하려 한다면 이 섹션의 설명을 따라야 합니다. 미래에도 계속 작동할 것은 보장하지 않습니다.
 
-You will have to make `fetch` available globally, either:
+`fetch` 함수를 전역으로 사용할 수 있도록 해야 합니다. 다음 중 하나를 사용하세요.
 
-- run your application with `NODE_OPTIONS='--experimental-fetch' node ...`, or
-- install `node-fetch` and follow the instructions [here](https://github.com/node-fetch/node-fetch#providing-global-access)
+- 당신의 애플리케이션을 `NODE_OPTIONS='--experimental-fetch' node ...`와 함께 실행하거나,
+- `node-fetch`를 설치하고 [여기](https://github.com/node-fetch/node-fetch#providing-global-access)의 설명을 따르세요.
 
-Additionally you'll have to polyfill `unstructuredClone`, eg. by installing `core-js` and following the instructions [here](https://github.com/zloirock/core-js).
+추가로, `unstructuredClone`을 지원 가능하도록 변환해야 합니다. 예를 들면, `core-js`를 설치하고 [여기](https://github.com/zloirock/core-js)의 설명을 따르세요.
 
-If you are running this on Node.js 18+, you do not need to do anything.
+Node.js 18 이상에서 실행하는 경우, 아무것도 할 필요가 없습니다.


### PR DESCRIPTION
Translated the whole 'Getting Started' section into Korean.

- /ko/docs/getting-started/install
- /ko/docs/getting-started/guide-llm
- /ko/docs/getting-started/guide-chat