### PR TITLE
Translate 'Model' page into Korean

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/additional_functionality.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/additional_functionality.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Additional Functionality
+sidebar_label: 추가 기능
 ---
 
 import CodeBlock from "@theme/CodeBlock";
@@ -7,37 +7,39 @@ import Example from "@examples/models/chat/chat.ts";
 import StreamingExample from "@examples/models/chat/chat_streaming.ts";
 import TimeoutExample from "@examples/models/chat/chat_timeout.ts";
 
-# Additional Functionality: Chat Models
+# 추가 기능: Chat Models
 
-We offer a number of additional features for chat models. In the examples below, we'll be using the `ChatOpenAI` model.
+저희는 채팅 모델을 위한 여러 가지 추가 기능을 제공합니다. 아래 예제에서는 `ChatOpenAI` 모델을 사용하겠습니다.
 
-## Additional Methods
+## 추가 메소드
 
-LangChain provides a number of additional methods for interacting with chat models:
+LangChain은 채팅 모델과 상호작용하기 위한 여러 가지 추가 메서드를 제공합니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-## Streaming
+## 스트리밍
 
-Similar to LLMs, you can stream responses from a chat model. This is useful for chatbots that need to respond to user input in real-time.
+LLM과 마찬가지로 채팅 모델에서 응답을 스트리밍할 수 있습니다. 이는 사용자 입력에 실시간으로 응답해야 하는 챗봇에 유용합니다.
 
 <CodeBlock language="typescript">{StreamingExample}</CodeBlock>
 
-## Adding a timeout
+## 타임아웃 추가
 
-By default, LangChain will wait indefinitely for a response from the model provider. If you want to add a timeout, you can pass a `timeout` option, in milliseconds, when you instantiate the model. For example, for OpenAI:
+기본적으로 LangChain은 모델 공급자의 응답을 무기한 대기합니다. 타임아웃을 추가하려면 모델을 인스턴스화할 때 밀리초 단위의 `timeout` 옵션을 전달하면 됩니다.
+
+예를 들어 OpenAI의 경우
 
 <CodeBlock language="typescript">{TimeoutExample}</CodeBlock>
 
-Currently, the timeout option is only supported for OpenAI models.
+현재 타임아웃 옵션은 OpenAI 모델에만 지원됩니다.
 
-## Dealing with Rate Limits
+## 속도 제한 처리
 
-Some providers have rate limits. If you exceed the rate limit, you'll get an error. To help you deal with this, LangChain provides a `maxConcurrency` option when instantiating a Chat Model. This option allows you to specify the maximum number of concurrent requests you want to make to the provider. If you exceed this number, LangChain will automatically queue up your requests to be sent as previous requests complete.
+일부 제공업체에는 속도 제한이 있습니다. 속도 제한을 초과하면 오류가 발생합니다. 이 문제를 해결하기 위해 LangChain은 채팅 모델을 인스턴스화할 때 '최대 동시성' 옵션을 제공합니다. 이 옵션을 사용하면 공급자에게 요청할 최대 동시 요청 수를 지정할 수 있습니다. 이 숫자를 초과하면 이전 요청이 완료될 때 전송할 요청을 자동으로 대기열에 추가합니다.
 
-For example, if you set `maxConcurrency: 5`, then LangChain will only send 5 requests to the provider at a time. If you send 10 requests, the first 5 will be sent immediately, and the next 5 will be queued up. Once one of the first 5 requests completes, the next request in the queue will be sent.
+예를 들어, '최대 동시성: 5'를 설정하면 LangChain은 한 번에 5개의 요청만 공급자에게 보냅니다. 10개의 요청을 보내면 처음 5개는 즉시 전송되고 다음 5개는 대기열에 대기합니다. 처음 5개의 요청 중 하나가 완료되면 대기열의 다음 요청이 전송됩니다.
 
-To use this feature, simply pass `maxConcurrency: <number>` when you instantiate the LLM. For example:
+이 기능을 사용하려면 `maxConcurrency: <숫자>`를 전달하면 됩니다.
 
 ```typescript
 import { ChatOpenAI } from "langchain/chat_models/openai";
@@ -45,9 +47,9 @@ import { ChatOpenAI } from "langchain/chat_models/openai";
 const model = new ChatOpenAI({ maxConcurrency: 5 });
 ```
 
-## Dealing with API Errors
+## API 에러 처리
 
-If the model provider returns an error from their API, by default LangChain will retry up to 6 times on an exponential backoff. This enables error recovery without any additional effort from you. If you want to change this behavior, you can pass a `maxRetries` option when you instantiate the model. For example:
+모델 공급자가 API에서 오류를 반환하는 경우, 기본적으로 LangChain은 지수 백오프를 사용하여 최대 6회까지 재시도합니다. 이를 통해 사용자의 추가 노력 없이 오류를 복구할 수 있습니다. 이 동작을 변경하려면 모델을 인스턴스화할 때 '최대 재시도' 옵션을 전달하면 됩니다.
 
 ```typescript
 import { ChatOpenAI } from "langchain/chat_models/openai";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/index.mdx
@@ -7,34 +7,34 @@ import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/models/chat/chat_quick_start.ts";
 import DocCardList from "@theme/DocCardList";
 
-# Getting Started: Chat Models
+# Chat Models 시작하기
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/models/chat-model)
 :::
 
-LangChain provides a standard interface for using chat models. Chat models are a variation on language models.
-While chat models use language models under the hood, the interface they expose is a bit different.
-Rather than expose a "text in, text out" API, they expose an interface where "chat messages" are the inputs and outputs.
+LangChain은 채팅 모델을 사용하기 위한 표준 인터페이스를 제공합니다. 채팅 모델은 언어 모델의 변형입니다.
+채팅 모델은 내부적으로 언어 모델을 사용하지만, 노출되는 인터페이스는 약간 다릅니다.
+"텍스트 입력, 텍스트 출력" API를 노출하는 대신 "채팅 메시지"가 입력 및 출력인 인터페이스를 노출합니다.
 
-## Chat Messages
+## 채팅 메시지
 
-A `ChatMessage` is what we refer to as the modular unit of information for a chat model.
-At the moment, this consists of a `"text"` field, which refers to the content of the chat message.
+`ChatMessage`는 채팅 모델의 모듈식 정보 단위라고 할 수 있습니다.
+현재 이것은 채팅 메시지의 내용을 나타내는 `"text"` 필드로 구성되어 있습니다.
 
-There are currently four different classes of `ChatMessage` supported by LangChain:
+현재 LangChain에서 지원하는 `ChatMessage` 클래스는 네 가지가 있습니다:
 
-- `HumanChatMessage`: A chat message that is sent as if from a Human's point of view.
-- `AIChatMessage`: A chat message that is sent from the point of view of the AI system to which the Human is corresponding.
-- `SystemChatMessage`: A chat message that gives the AI system some information about the conversation. This is usually sent at the beginning of a conversation.
-- `ChatMessage`: A generic chat message, with not only a `"text"` field but also an arbitrary `"role"` field.
+- `HumanChatMessage`: 마치 사람의 관점에서 보내는 것처럼 보내는 채팅 메시지입니다.
+- `AIChatMessage`: 사람을 대응하는 인공지능 시스템의 관점에서 보내는 채팅 메시지입니다.
+- `SystemChatMessage`: 인공지능 시스템에 대화에 대한 정보를 제공하는 채팅 메시지입니다. 일반적으로 대화가 시작될 때 전송됩니다.
+- `ChatMessage`: `"text"` 필드뿐만 아니라 임의의 `"role"` 필드가 있는 일반적인 채팅 메시지입니다.
 
-> **_Note:_** Currently, the only chat-based model we support is `ChatOpenAI` (with gpt-4 and gpt-3.5-turbo), but anticipate adding more in the future.
+> **_Note:_** 현재 저희가 지원하는 유일한 채팅 기반 모델은 `ChatOpenAI`(gpt-4 및 gpt-3.5-turbo 포함)이지만, 앞으로 더 추가될 예정입니다.
 
-To get started, simply use the `call` method of an `LLM` implementation, passing in a `string` input. In this example, we are using the `ChatOpenAI` implementation:
+시작하려면 `LLM` 구현체의 `call` 메서드를 사용하여 `string` 입력을 전달하기만 하면 됩니다. 이 예제에서는 `ChatOpenAI`를 사용하여 채팅 모델을 구현하고 있습니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-## Dig deeper
+## 더 자세히 살펴보기
 
 <DocCardList />

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/integrations.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/chat/integrations.mdx
@@ -1,21 +1,21 @@
 ---
 sidebar_position: 3
-sidebar_label: Integrations
+sidebar_label: 통합
 ---
 
 import CodeBlock from "@theme/CodeBlock";
 
-# Integrations: Chat Models
+# 통합: Chat Models
 
-LangChain offers a number of Chat Models implementations that integrate with various model providers. These are:
+LangChain은 다양한 모델 공급자와 통합되는 여러 채팅 모델 구현을 제공합니다. 다음은 다음과 같습니다.
 
-## `ChatOpenAI`
+## `ChatOpenAI` - OpenAI 채팅 모델
 
 import OpenAI from "@examples/models/chat/integration_openai.ts";
 
 <CodeBlock language="typescript">{OpenAI}</CodeBlock>
 
-## `ChatAnthropic`
+## `ChatAnthropic` - Anthropic 채팅 모델
 
 import Anthropic from "@examples/models/chat/integration_anthropic.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/additional_functionality.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/additional_functionality.mdx
@@ -1,29 +1,29 @@
 ---
-sidebar_label: Additional Functionality
+sidebar_label: 추가 기능
 ---
 
 import CodeBlock from "@theme/CodeBlock";
 import TimeoutExample from "@examples/models/embeddings/openai_timeout.ts";
 
-# Additional Functionality: Embeddings
+# 추가 기능 : Embeddings
 
-We offer a number of additional features for chat models. In the examples below, we'll be using the `ChatOpenAI` model.
+저희는 채팅 모델을 위한 여러 가지 추가 기능을 제공합니다. 아래 예제에서는 `ChatOpenAI` 모델을 사용하겠습니다.
 
-## Adding a timeout
+## 타임아웃 추가
 
-By default, LangChain will wait indefinitely for a response from the model provider. If you want to add a timeout, you can pass a `timeout` option, in milliseconds, when you instantiate the model. For example, for OpenAI:
+기본적으로 LangChain은 모델 공급자의 응답을 무기한 대기합니다. 타임아웃을 추가하려면 모델을 인스턴스화할 때 밀리초 단위의 `timeout` 옵션을 전달하면 됩니다. 예를 들어 OpenAI의 경우
 
 <CodeBlock language="typescript">{TimeoutExample}</CodeBlock>
 
-Currently, the timeout option is only supported for OpenAI models.
+현재 타임아웃 옵션은 OpenAI 모델에만 지원됩니다.
 
-## Dealing with Rate Limits
+## 속도 제한 처리
 
-Some providers have rate limits. If you exceed the rate limit, you'll get an error. To help you deal with this, LangChain provides a `maxConcurrency` option when instantiating an Embeddings model. This option allows you to specify the maximum number of concurrent requests you want to make to the provider. If you exceed this number, LangChain will automatically queue up your requests to be sent as previous requests complete.
+일부 제공업체에는 속도 제한이 있습니다. 속도 제한을 초과하면 오류가 발생합니다. 이 문제를 해결하기 위해 LangChain은 임베딩 모델을 인스턴스화할 때 '최대 동시성' 옵션을 제공합니다. 이 옵션을 사용하면 공급자에게 요청할 최대 동시 요청 수를 지정할 수 있습니다. 이 숫자를 초과하면 이전 요청이 완료될 때 전송할 요청을 자동으로 대기열에 추가합니다.
 
-For example, if you set `maxConcurrency: 5`, then LangChain will only send 5 requests to the provider at a time. If you send 10 requests, the first 5 will be sent immediately, and the next 5 will be queued up. Once one of the first 5 requests completes, the next request in the queue will be sent.
+예를 들어, '최대 동시성: 5'를 설정하면 LangChain은 한 번에 5개의 요청만 공급자에게 보냅니다. 10개의 요청을 보내면 처음 5개는 즉시 전송되고 다음 5개는 대기열에 대기합니다. 처음 5개의 요청 중 하나가 완료되면 대기열의 다음 요청이 전송됩니다.
 
-To use this feature, simply pass `maxConcurrency: <number>` when you instantiate the LLM. For example:
+이 기능을 사용하려면 `maxConcurrency: <숫자>`를 전달하면 됩니다.
 
 ```typescript
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
@@ -31,9 +31,9 @@ import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 const model = new OpenAIEmbeddings({ maxConcurrency: 5 });
 ```
 
-## Dealing with API Errors
+## API 에러 처리
 
-If the model provider returns an error from their API, by default LangChain will retry up to 6 times on an exponential backoff. This enables error recovery without any additional effort from you. If you want to change this behavior, you can pass a `maxRetries` option when you instantiate the model. For example:
+모델 공급자가 API에서 오류를 반환하면 기본적으로 LangChain은 지수 백오프에서 최대 6회까지 재시도합니다. 이를 통해 사용자의 추가 노력 없이 오류를 복구할 수 있습니다. 이 동작을 변경하려면 모델을 인스턴스화할 때 '최대 재시도' 옵션을 전달하면 됩니다.
 
 ```typescript
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/index.mdx
@@ -5,15 +5,15 @@ sidebar_label: Embeddings
 
 import DocCardList from "@theme/DocCardList";
 
-# Getting Started: Embeddings
+# 임베딩 시작하기
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/models/text-embedding-model)
 :::
 
-Embeddings can be used to create a numerical representation of textual data. This numerical representation is useful because it can be used to find similar documents.
+임베딩은 텍스트 데이터를 숫자 표현으로 만드는 데 사용할 수 있습니다. 이 숫자 표현은 유사한 문서를 찾는 데 사용할 수 있기 때문에 유용합니다.
 
-Below is an example of how to use the OpenAI embeddings. Embeddings occasionally have different embedding methods for queries versus documents, so the embedding class exposes a `embedQuery` and `embedDocuments` method.
+다음은 OpenAI 임베딩을 사용하는 방법의 예입니다. 임베딩은 쿼리와 문서에 대한 임베딩 메서드가 다른 경우가 있으므로 임베딩 클래스에는 `embedQuery` 및 `embedDocuments` 메서드가 노출되어 있습니다.
 
 ```typescript
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/integrations.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/embeddings/integrations.mdx
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 3
-sidebar_label: Integrations
+sidebar_label: 통합
 ---
 
-# Integrations: Embeddings
+# 통합: Embeddings
 
-LangChain offers a number of Embeddings implementations that integrate with various model providers. These are:
+LangChain은 다양한 모델 공급자와 통합되는 여러 임베딩 구현을 제공합니다. 다음은 다음과 같습니다:
 
 ## `OpenAIEmbeddings`
 
-The `OpenAIEmbeddings` class uses the OpenAI API to generate embeddings for a given text. By default it strips new line characters from the text, as recommended by OpenAI, but you can disable this by passing `stripNewLines: false` to the constructor.
+OpenAIEmbeddings`클래스는 OpenAI API를 사용하여 주어진 텍스트에 대한 임베딩을 생성합니다. 기본적으로 이 클래스는 OpenAI에서 권장하는 대로 텍스트에서 줄 바꿈 문자를 제거하지만, 생성자에`stripNewLines: false`를 전달하여 이 기능을 비활성화할 수 있습니다.
 
 ```typescript
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/models/index.mdx
@@ -6,29 +6,29 @@ sidebar_label: Models
 
 import DocCardList from "@theme/DocCardList";
 
-# Models
+# 모델
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/models/)
 :::
 
-Models are a core component of LangChain. LangChain is not a provider of models, but rather provides a standard interface through which you can interact with a variety of language models.
-LangChain provides support for both text-based Large Language Models (LLMs), Chat Models, and Text Embedding models.
+모델은 LangChain의 핵심 구성 요소입니다. LangChain은 모델을 제공하는 것이 아니라 다양한 언어 모델과 상호 작용할 수 있는 표준 인터페이스를 제공합니다.
+LangChain은 텍스트 기반 대규모 언어 모델(LLM), 채팅 모델, 텍스트 임베딩 모델을 모두 지원합니다.
 
-LLMs use a text-based input and output, while Chat Models use a message-based input and output.
+LLM은 텍스트 기반 입력과 출력을 사용하는 반면, 채팅 모델은 메시지 기반 입력과 출력을 사용합니다.
 
-> **_Note:_** Chat model APIs are fairly new, so we are still figuring out the correct abstractions. If you have any feedback, please let us know!
+> **_Note:_** 채팅 모델 API는 새로운 기능이기 때문에 아직 정확한 추상화를 파악하는 중입니다. 피드백이 있으시면 언제든지 알려주세요!
 
-## All Models
+## 전체 모델
 
 <DocCardList />
 
 ## Advanced
 
-_This section is for users who want a deeper technical understanding of how LangChain works. If you are just getting started, you can skip this section._
+이 섹션은 LangChain의 작동 방식에 대해 더 깊은 기술적 이해를 원하는 사용자를 위한 섹션입니다. 이제 막 시작하신다면 이 섹션을 건너뛰셔도 됩니다.
 
-Both LLMs and Chat Models are built on top of the `BaseLanguageModel` class. This class provides a common interface for all models, and allows us to easily swap out models in chains without changing the rest of the code.
+LLM과 채팅 모델은 모두 `BaseLanguageModel` 클래스를 기반으로 구축됩니다. 이 클래스는 모든 모델에 공통 인터페이스를 제공하며, 나머지 코드를 변경하지 않고도 체인에서 모델을 쉽게 교체할 수 있게 해줍니다.
 
-The `BaseLanguageModel` class has two abstract methods: `generatePrompt` and `getNumTokens`, which are implemented by `BaseChatModel` and `BaseLLM` respectively.
+BaseLanguageModel`클래스에는 두 개의 추상 메서드인`generatePrompt`와 `getNumTokens`가 있으며, 이는 각각 `BaseChatModel`과 `BaseLLM`에 의해 구현됩니다.
 
-`BaseLLM` is a subclass of `BaseLanguageModel` that provides a common interface for LLMs while `BaseChatModel` is a subclass of `BaseLanguageModel` that provides a common interface for chat models.
+BaseLLM`은 `BaseLanguageModel`의 서브클래스로 LLM에 대한 공통 인터페이스를 제공하며, `BaseChatModel`은 `BaseLanguageModel`의 서브클래스로 채팅 모델에 대한 공통 인터페이스를 제공합니다.


### PR DESCRIPTION
Translate parts of model pages
- /ko/docs/modules/models
- /ko/docs/modules/models/chat
- /ko/docs/modules/models/chat/integrations
- /ko/docs/modules/models/chat/additional_functionality
- /ko/docs/modules/models/embeddings/
- /ko/docs/modules/models/embeddings/integrations
- /ko/docs/modules/models/embeddings/additional_functionality

----

The translation of the LLM section inside the model page has been translated except for that part because it is not the person in charge.
