### PR TITLE
Translate the vector store section in the indexes page into Korean

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/index.mdx
@@ -3,23 +3,23 @@ sidebar_label: "Vector Stores"
 sidebar_position: 3
 ---
 
-# Getting Started: Vector Stores
+# 시작하기: Vector Stores
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/indexing/vectorstore)
 :::
 
-A vector store is a particular type of database optimized for storing documents and their [embeddings](../../models/embeddings/), and then fetching of the most relevant documents for a particular query, ie. those whose embeddings are most similar to the embedding of the query.
+벡터 스토어는 documents와 [embeddings](../../models/embeddings/)을 저장한 다음 특정 쿼리에 가장 관련성이 높은 documents, 즉 쿼리의 임베딩과 가장 유사한 embeddings을 가져오는 데 최적화된 특정 유형의 데이터베이스입니다.
 
 ```typescript
 interface VectorStore {
   /**
-   * Add more documents to an existing VectorStore
+   * 기존 VectorStore에 Documents 더 추가합니다.
    */
   addDocuments(documents: Document[]): Promise<void>;
 
   /**
-   * Search for the most similar documents to a query
+   * 쿼리와 가장 유사한 Documents를 검색합니다.
    */
   similaritySearch(
     query: string,
@@ -28,8 +28,7 @@ interface VectorStore {
   ): Promise<Document[]>;
 
   /**
-   * Search for the most similar documents to a query,
-   * and return their similarity score
+   * 쿼리와 가장 유사한 Documents를 검색하고, 유사도 점수를 반환합니다.
    */
   similaritySearchWithScore(
     query: string,
@@ -38,19 +37,17 @@ interface VectorStore {
   ): Promise<[object, number][]>;
 
   /**
-   * Turn a VectorStore into a Retriever
+   * VectorStore 를 Retriever 로 변환합니다.
    */
   asRetriever(k?: number): BaseRetriever;
 
   /**
-   * Advanced: Add more documents to an existing VectorStore,
-   * when you already have their embeddings
+   * 고급: 이미 Embeddings 된 데이터가 있는 경우, 기존의 VectorStore 에 Documents 를 추가합니다.
    */
   addVectors(vectors: number[][], documents: Document[]): Promise<void>;
 
   /**
-   * Advanced: Search for the most similar documents to a query,
-   * when you already have the embedding of the query
+   * 고급: 이미 Query Embedding 이 있는 경우, Query 와 가장 유사한 문서를 검색합니다.
    */
   similaritySearchVectorWithScore(
     query: number[],
@@ -60,7 +57,8 @@ interface VectorStore {
 }
 ```
 
-You can create a vector store from a list of [Documents](../../schema/document), or from a list of texts and their corresponding metadata. You can also create a vector store from an existing index, the signature of this method depends on the vector store you're using, check the documentation of the vector store you're interested in.
+[Documents](../../schema/document) 목록 또는 텍스트 목록과 메타 데이터에서 VectorStore 를 만들 수 있습니다.
+기존 인덱스에서 VectorStore 를 만들 수도 있으며 이 방법의 경우 VectorStore 에 따라 메소드 시그니처가 다르므로 관심 있는 VectorStore의 설명서를 확인하세요.
 
 ```typescript
 abstract class BaseVectorStore implements VectorStore {
@@ -79,18 +77,18 @@ abstract class BaseVectorStore implements VectorStore {
 }
 ```
 
-## Which one to pick?
+## 어떤 것을 선택해야 할까요?
 
-Here's a quick guide to help you pick the right vector store for your use case:
+다음은 사용 사례에 적합한 VectorStore 를 선택하는 데 도움을 줄 수 있는 빠른 가이드 입니다.
 
-- If you're after something that can just run inside your Node.js application, in-memory, without any other servers to stand up, then go for [HNSWLib](./integrations/hnswlib)
-- If you're looking for something that can run in-memory in browser-like environments, then go for [MemoryVectorStore](./integrations/memory)
-- If you come from Python and you were looking for something similar to FAISS, pick [HNSWLib](./integrations/hnswlib)
-- If you're looking for an open-source full-featured vector database that you can run locally in a docker container, then go for [Chroma](./integrations/chroma)
-- If you're using Supabase already then look at the [Supabase](./integrations/supabase) vector store to use the same Postgres database for your embeddings too
-- If you're looking for a production-ready vector store you don't have to worry about hosting yourself, then go for [Pinecone](./integrations/pinecone)
+- 다른 서버를 구출할 필요 없이 Node.js 애플리케이션 내부에서 in-memory로 실행 가능한 것을 찾고 있다면, [HNSWLib](./integrations/hnswlib)를 선택하세요.
+- 브라우저와 유사한 환경의 in-memory로 실행 가능한 것을 찾고 있다면, [MemoryVectorStore](./integrations/memory)를 선택하세요.
+- Python에서 FAISS와 유사한 것을 찾고 있다면, [HNSWLib](./integrations/hnswlib)를 선택하세요.
+- Docker 컨테이너에서 로컬로 실행할 수 있는 모든 기능을 갖춘 오픈 소스 벡터 데이터베이스를 찾고 있다면, [Chroma](./integrations/chroma)를 선택하세요.
+- 이미 [Supabase](./integrations/supabase)를 사용중이라면, Embeddings에도 동일한 Postgres 데이터베이스를 사용하길 원한다면 Supabase VectorStore를 살펴보세요.
+- 직접 호스팅할 필요가 없는 프로덕션용 벡터 스토어를 찾고 있다면, [Pinecone](./integrations/pinecone)를 선택하세요.
 
-## All Vector Stores
+## 모든 Vector Stores
 
 import DocCardList from "@theme/DocCardList";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/index.mdx
@@ -9,12 +9,12 @@ sidebar_position: 3
 [Conceptual Guide](https://docs.langchain.com/docs/components/indexing/vectorstore)
 :::
 
-벡터 스토어는 documents와 [embeddings](../../models/embeddings/)을 저장한 다음 특정 쿼리에 가장 관련성이 높은 documents, 즉 쿼리의 임베딩과 가장 유사한 embeddings을 가져오는 데 최적화된 특정 유형의 데이터베이스입니다.
+Vector Stores는 Documents와 [Embeddings](../../models/embeddings/)을 저장한 다음 특정 쿼리에 가장 관련성이 높은 documents, 즉 쿼리의 임베딩과 가장 유사한 embeddings을 가져오는 데 최적화된 특정 유형의 데이터베이스입니다.
 
 ```typescript
 interface VectorStore {
   /**
-   * 기존 VectorStore에 Documents 더 추가합니다.
+   * 기존 VectorStore에 새로운 Documents 더 추가합니다.
    */
   addDocuments(documents: Document[]): Promise<void>;
 
@@ -42,12 +42,12 @@ interface VectorStore {
   asRetriever(k?: number): BaseRetriever;
 
   /**
-   * 고급: 이미 Embeddings 된 데이터가 있는 경우, 기존의 VectorStore 에 Documents 를 추가합니다.
+   * 심화: 이미 Embeddings 된 데이터가 있는 경우, 기존의 VectorStore 에 Documents 를 추가합니다.
    */
   addVectors(vectors: number[][], documents: Document[]): Promise<void>;
 
   /**
-   * 고급: 이미 Query Embedding 이 있는 경우, Query 와 가장 유사한 문서를 검색합니다.
+   * 심화: 이미 Query Embedding 이 있는 경우, Query 와 가장 유사한 문서를 검색합니다.
    */
   similaritySearchVectorWithScore(
     query: number[],
@@ -57,8 +57,8 @@ interface VectorStore {
 }
 ```
 
-[Documents](../../schema/document) 목록 또는 텍스트 목록과 메타 데이터에서 VectorStore 를 만들 수 있습니다.
-기존 인덱스에서 VectorStore 를 만들 수도 있으며 이 방법의 경우 VectorStore 에 따라 메소드 시그니처가 다르므로 관심 있는 VectorStore의 설명서를 확인하세요.
+텍스트의 목록과 그 메타 데이터에서 벡터 스토어를 새롭게 만들 수 있습니다
+기존의 인덱스로부터 새로운 벡터 스토어를 만들 수 있습니다. 다만 이 방법의 경우 사용하는 벡터 스토어에 따라 메소드 시그너쳐가 다르기 때문에 본인이 사용하는 벡터 스토어의 기술 문서를 확인하세요.
 
 ```typescript
 abstract class BaseVectorStore implements VectorStore {

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/chroma.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/chroma.mdx
@@ -2,30 +2,30 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Chroma
 
-Chroma is an open-source Apache 2.0 embedding database.
+Chroma 는 오픈소스 Apache 2.0 임베딩 데이터베이스 입니다.
 
-## Setup
+## 설치
 
-1. Run chroma with Docker on your computer [docs](https://docs.trychroma.com/api-reference)
-2. Install the Chroma JS SDK.
+1. 로컬 컴퓨터에서 Docker 로 Chroma 실행[docs](https://docs.trychroma.com/api-reference)
+2. Chroma JS SDK를 설치
 
 ```bash npm2yarn
 npm install -S chromadb
 ```
 
-## Usage, Index and query Documents
+## Index, query Documents 사용하기
 
 import FromDocs from "@examples/indexes/vector_stores/chroma/fromDocs.ts";
 
 <CodeBlock language="typescript">{FromDocs}</CodeBlock>
 
-## Usage, Index and query texts
+## Index and query texts 사용하기
 
 import FromTexts from "@examples/indexes/vector_stores/chroma/fromTexts.ts";
 
 <CodeBlock language="typescript">{FromTexts}</CodeBlock>
 
-## Usage, Query docs from existing collection
+## 기존에 존재하는 Collection에서 문서 쿼리하기
 
 import Search from "@examples/indexes/vector_stores/chroma/search.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/chroma.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/chroma.mdx
@@ -13,13 +13,13 @@ Chroma 는 오픈소스 Apache 2.0 임베딩 데이터베이스 입니다.
 npm install -S chromadb
 ```
 
-## Index, query Documents 사용하기
+## Index 및 Query documents 사용하기
 
 import FromDocs from "@examples/indexes/vector_stores/chroma/fromDocs.ts";
 
 <CodeBlock language="typescript">{FromDocs}</CodeBlock>
 
-## Index and query texts 사용하기
+## Index 및 Query texts 사용하기
 
 import FromTexts from "@examples/indexes/vector_stores/chroma/fromTexts.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/hnswlib.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/hnswlib.mdx
@@ -7,34 +7,34 @@ import CodeBlock from "@theme/CodeBlock";
 # HNSWLib
 
 :::tip Compatibility
-Only available on Node.js.
+Node.js에서만 사용 가능합니다.
 :::
 
-HNSWLib is an in-memory vectorstore that can be saved to a file. It uses [HNSWLib](https://github.com/nmslib/hnswlib).
+HNSWLib는 파일에 저장할 수 있는 in-memory vectorstore 입니다. 해당 문서에서는 [HNSWLib](https://github.com/nmslib/hnswlib)를 사용합니다.
 
-## Setup
+## 설치
 
-You can install it with
+다음 명령어로 설치할 수 있습니다.
 
 ```bash npm2yarn
 npm install hnswlib-node
 ```
 
-## Usage
+## 사용
 
-### Create a new index from texts
+### 텍스트에서 새 index 만들기
 
 import ExampleTexts from "@examples/indexes/vector_stores/hnswlib.ts";
 
 <CodeBlock language="typescript">{ExampleTexts}</CodeBlock>
 
-### Create a new index from a loader
+### loader에서 새 index 만들기
 
 import ExampleLoader from "@examples/indexes/vector_stores/hnswlib_fromdocs.ts";
 
 <CodeBlock language="typescript">{ExampleLoader}</CodeBlock>
 
-### Save an index to a file and load it again
+### index를 파일에 저장하고 다시 로드하기
 
 import ExampleSave from "@examples/indexes/vector_stores/hnswlib_saveload.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/index.mdx
@@ -1,9 +1,9 @@
 ---
-sidebar_label: Integrations
+sidebar_label: 통합
 ---
 
 import DocCardList from "@theme/DocCardList";
 
-# Vector Stores: Integrations
+# Vector Stores: 통합
 
 <DocCardList />

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/memory.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/memory.mdx
@@ -8,23 +8,23 @@ import CodeBlock from "@theme/CodeBlock";
 
 # `MemoryVectorStore`
 
-MemoryVectorStore is an in-memory, ephemeral vectorstore that stores embeddings in-memory and does an exact, linear search for the most similar embeddings. The default similarity metric is cosine similarity, but can be changed to any of the similarity metrics supported by [ml-distance](https://mljs.github.io/distance/modules/similarity.html).
+MemoryVectorStore는 Embeddings을 메모리에 저장하고 가장 유사한 Embeddings을 선형적으로 정확하게 검색하는 in-memory vector store입니다. 기본 유사도 메트릭은 cosine 유사도이지만, [ml-distance](https://mljs.github.io/distance/modules/similarity.html)에서 지원하는 모든 유사도 메트릭으로 변경할 수 있습니다.
 
-## Usage
+## 사용 방법
 
-### Create a new index from texts
+### 텍스트에서 새 index 만들기
 
 import ExampleTexts from "@examples/indexes/vector_stores/memory.ts";
 
 <CodeBlock language="typescript">{ExampleTexts}</CodeBlock>
 
-### Create a new index from a loader
+### loader에서 새 index 만들기
 
 import ExampleLoader from "@examples/indexes/vector_stores/memory_fromdocs.ts";
 
 <CodeBlock language="typescript">{ExampleLoader}</CodeBlock>
 
-### Use a custom similarity metric
+### 사용자 정의 유사성 매트릭 사용하기
 
 import ExampleCustom from "@examples/indexes/vector_stores/memory_custom_similarity.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/milvus.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/milvus.md
@@ -4,29 +4,29 @@ sidebar_class_name: node-only
 
 # Milvus
 
-[Milvus](https://milvus.io/) is a vector database built for embeddings similarity search and AI applications.
+[Milvus](https://milvus.io/)는 임베딩 유사도 검색 및 AI 애플리케이션을 위해 구축된 벡터 데이터베이스입니다.
 
 :::tip Compatibility
-Only available on Node.js.
+Node.js에서만 사용 가능합니다.
 :::
 
 ## Setup
 
-1. Run Milvus instance with Docker on your computer [docs](https://milvus.io/docs/v2.1.x/install_standalone-docker.md)
-2. Install the Milvus Node.js SDK.
+1. 로컬 컴퓨터에서 Milvus instance를 Docker로 실행 [docs](https://milvus.io/docs/v2.1.x/install_standalone-docker.md)
+2. Milvus Node.js SDK를 설치
 
 ```bash npm2yarn
 npm install -S @zilliz/milvus2-sdk-node
 ```
 
-3. Setup Env variables for Milvus before running the code
+3. 코드 실행 전, Milvus 환경 변수 설정
 
 ```bash
 export OPENAI_API_KEY=YOUR_OPEN_API_HERE
 export MILVUS_URL=YOUR_MILVUS_URL_HERE # for example http://localhost:19530
 ```
 
-## Index and query docs
+## Index, query docs
 
 ```typescript
 import { Milvus } from "langchain/vectorstores/milvus";
@@ -53,7 +53,7 @@ const vectorStore = await Milvus.fromTexts(
   }
 );
 
-// or alternatively from docs
+// 또는 문서에서 가져오는 방법
 const vectorStore = await Milvus.fromDocuments(docs, new OpenAIEmbeddings(), {
   collectionName: "goldel_escher_bach",
 });
@@ -61,7 +61,7 @@ const vectorStore = await Milvus.fromDocuments(docs, new OpenAIEmbeddings(), {
 const response = await vectorStore.similaritySearch("scared", 2);
 ```
 
-## Query docs from existing collection
+## 기존에 존재하는 Collection에서 문서 쿼리하기
 
 ```typescript
 import { Milvus } from "langchain/vectorstores/milvus";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/opensearch.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/opensearch.md
@@ -8,7 +8,7 @@ sidebar_class_name: node-only
 Node.js에서만 사용합니다.
 :::
 
-[OpenSearch](https://opensearch.org/)는 [Elasticsearch](https://www.elastic.co/elasticsearch/)의 자식(fork) 오픈소스로, Elasticsearch API와 완벽하게 호환됩니다. 이를 이용하여 가장 가까운 근사 검색에 대한 자세한 내용은 [여기](https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/)를 참고하세요.
+[OpenSearch](https://opensearch.org/)는 [Elasticsearch](https://www.elastic.co/elasticsearch/)의 포크(fork)한 오픈소스로, Elasticsearch API와 완벽하게 호환됩니다. 이를 이용하여 가장 가까운 근사 검색에 대한 자세한 내용은 [여기](https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/)를 참고하세요.
 
 Langchain.js는 OpenSearch vectorstore를 사용하기 위한 클라이언트로 [@opensearch-project/opensearch](https://opensearch.org/docs/latest/clients/javascript/index/)를 허용합니다.
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/opensearch.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/opensearch.md
@@ -5,20 +5,20 @@ sidebar_class_name: node-only
 # OpenSearch
 
 :::tip Compatibility
-Only available on Node.js.
+Node.js에서만 사용합니다.
 :::
 
-[OpenSearch](https://opensearch.org/) is a fork of [Elasticsearch](https://www.elastic.co/elasticsearch/) that is fully compatible with the Elasticsearch API. Read more about their support for Approximate Nearest Neighbors [here](https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/).
+[OpenSearch](https://opensearch.org/)는 [Elasticsearch](https://www.elastic.co/elasticsearch/)의 자식(fork) 오픈소스로, Elasticsearch API와 완벽하게 호환됩니다. 이를 이용하여 가장 가까운 근사 검색에 대한 자세한 내용은 [여기](https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/)를 참고하세요.
 
-Langchain.js accepts [@opensearch-project/opensearch](https://opensearch.org/docs/latest/clients/javascript/index/) as the client for OpenSearch vectorstore.
+Langchain.js는 OpenSearch vectorstore를 사용하기 위한 클라이언트로 [@opensearch-project/opensearch](https://opensearch.org/docs/latest/clients/javascript/index/)를 허용합니다.
 
-## Setup
+## 설치
 
 ```bash npm2yarn
 npm install -S @opensearch-project/opensearch
 ```
 
-You'll also need to have an OpenSearch instance running. You can use the [official Docker image](https://opensearch.org/docs/latest/opensearch/install/docker/) to get started. You can also find an example docker-compose file [here](https://github.com/hwchase17/langchainjs/blob/main/examples/src/indexes/vector_stores/opensearch/docker-compose.yml).
+OpenSearch 인스턴스가 실행중인 상태여야 합니다. [공식 Docker 이미지](https://opensearch.org/docs/latest/opensearch/install/docker/)를 사용하여 시작할 수 있습니다. [여기](https://github.com/hwchase17/langchainjs/blob/main/examples/src/indexes/vector_stores/opensearch/docker-compose.yml)를 참고하세요.
 
 ## Index docs
 
@@ -54,7 +54,7 @@ const docs = [
 
 await OpenSearchVectorStore.fromDocuments(docs, new OpenAIEmbeddings(), {
   client,
-  indexName: process.env.OPENSEARCH_INDEX, // Will default to `documents`
+  indexName: process.env.OPENSEARCH_INDEX, //기본 값은 `documents`입니다.
 });
 ```
 
@@ -75,7 +75,7 @@ const vectorStore = new OpenSearchVectorStore(new OpenAIEmbeddings(), {
   client,
 });
 
-/* Search the vector DB independently with meta filters */
+/* meta filters로 vector DB를 독립적으로 검색 */
 const results = await vectorStore.similaritySearch("hello world", 1);
 console.log(JSON.stringify(results, null, 2));
 /* [
@@ -87,7 +87,7 @@ console.log(JSON.stringify(results, null, 2));
     }
   ] */
 
-/* Use as part of a chain (currently no metadata filters) */
+/* chain의 일부로 사용 (현재 metadata filters 없음) */
 const model = new OpenAI();
 const chain = VectorDBQAChain.fromLLM(model, vectorStore, {
   k: 1,

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/pinecone.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/pinecone.md
@@ -5,10 +5,11 @@ sidebar_class_name: node-only
 # Pinecone
 
 :::tip Compatibility
-Only available on Node.js.
+Node.js에서만 사용 가능합니다.
 :::
 
-Langchain.js accepts [@pinecone-database/pinecone](https://docs.pinecone.io/docs/node-client) as the client for Pinecone vectorstore. Install the library with
+Langchain.js는 Pinecone vectorstore를 사용하기 위한 클라이언트로 [@pinecone-database/pinecone](https://docs.pinecone.io/docs/node-client)를 허용합니다.
+다음을 사용하여 라이브러리를 설치합니다.
 
 ```bash npm2yarn
 npm install -S dotenv langchain @pinecone-database/pinecone
@@ -80,7 +81,7 @@ const vectorStore = await PineconeStore.fromExistingIndex(
   { pineconeIndex }
 );
 
-/* Search the vector DB independently with meta filters */
+/* meta filters로 vector DB를 독립적으로 검색 */
 const results = await vectorStore.similaritySearch("pinecone", 1, {
   foo: "bar",
 });
@@ -94,7 +95,7 @@ console.log(results);
 ]
 */
 
-/* Use as part of a chain (currently no metadata filters) */
+/* chain의 일부로 사용 (현재 metadata filters 없음) */
 const model = new OpenAI();
 const chain = VectorDBQAChain.fromLLM(model, vectorStore, {
   k: 1,

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/prisma.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/prisma.mdx
@@ -1,22 +1,22 @@
 # Prisma
 
-For augmenting existing models in PostgreSQL database with vector search, Langchain supports using [Prisma](https://www.prisma.io/) together with PostgreSQL and [`pgvector`](https://github.com/pgvector/pgvector) Postgres extension.
+Langchain은 PostgreSQL 데이터베이스의 vector 검색을 위해 [Prisma](https://www.prisma.io/) 및 Postgres 확장자와 함께 [`pgvector`](https://github.com/pgvector/pgvector)를 사용하는 것을 지원합니다.
 
-## Setup
+## 설치
 
-### Setup database instance with Supabase
+### Supabase로 데이터베이스 인스턴스 설정
 
-Refer to the [Prisma and Supabase integration guide](https://supabase.com/docs/guides/integrations/prisma) to setup a new database instance with Supabase and Prisma.
+[Prisma와 Supabase 연동 가이드](https://supabase.com/docs/guides/integrations/prisma)를 참고하여 Supabase와 Prisma로 새로운 데이터베이스 인스턴스를 설정합니다.
 
-### Install Prisma
+### Prisma 설치
 
 ```bash npm2yarn
 npm install prisma
 ```
 
-### Setup `pgvector` self hosted instance with `docker-compose`
+### Docker-compose로 `pgvector` 자체 호스팅 인스턴스 설정
 
-`pgvector` provides a prebuilt Docker image that can be used to quickly setup a self-hosted Postgres instance.
+`pgvector` 는 자체 호스팅된 Postgres 인스턴스를 빠르게 설정하는 데 사용할 수 있는 사전 빌드된 도커 이미지를 제공합니다.
 
 ```yaml
 services:
@@ -35,9 +35,9 @@ volumes:
   db:
 ```
 
-### Create a new schema
+### 새 schema 생성
 
-Assuming you haven't created a schema yet, create a new model with a `vector` field of type `Unsupported("vector")`:
+아래 예시는 아직 스키마를 만들지 않았다고 가정하고, `Unsupported("vector")` 유형의 `vector` 필드가 있는 새 모델을 생성합니다.
 
 ```prisma
 model Document {
@@ -47,34 +47,34 @@ model Document {
 }
 ```
 
-Afterwards, create a new migration with `--create-only` to avoid running the migration directly.
+그 후, 마이그레이션을 직접 실행하지 않으려면 `--create-only`을 사용하여 새 마이그레이션을 생성합니다.
 
 ```bash npm2yarn
 npm run prisma migrate dev --create-only
 ```
 
-Add the following line to the newly created migration to enable `pgvector` extension if it hasn't been enabled yet:
+아직 활성화되지 않은 경우, 새로 생성된 마이그레이션에 다음 줄을 추가하여 `pgvector` 확장을 활성화합니다.
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
-Run the migration afterwards:
+그 후에 마이그레이션을 실행합니다.
 
 ```bash npm2yarn
 npm run prisma migrate dev
 ```
 
-## Usage
+## 사용
 
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/indexes/vector_stores/prisma_vectorstore/prisma.ts";
 import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/schema.prisma";
 
-Use the `withModel` method to get proper type hints for `metadata` field:
+`metadata` 필드에 대한 문서를 얻으려면 `withModel` 메서드를 사용할 수 있습니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
 
-The sample above uses the following schema:
+위의 샘플은 다음 스키마를 사용합니다.
 
 <CodeBlock language="prisma">{Schema}</CodeBlock>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/prisma.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/prisma.mdx
@@ -1,6 +1,6 @@
 # Prisma
 
-Langchain은 PostgreSQL 데이터베이스의 vector 검색을 위해 [Prisma](https://www.prisma.io/) 및 Postgres 확장자와 함께 [`pgvector`](https://github.com/pgvector/pgvector)를 사용하는 것을 지원합니다.
+Langchain은 PostgreSQL 데이터베이스의 vector 검색을 위해 [Prisma](https://www.prisma.io/) 및 Postgres 확장 플러그인과 함께 [`pgvector`](https://github.com/pgvector/pgvector)를 사용하는 것을 지원합니다.
 
 ## 설치
 
@@ -53,7 +53,7 @@ model Document {
 npm run prisma migrate dev --create-only
 ```
 
-아직 활성화되지 않은 경우, 새로 생성된 마이그레이션에 다음 줄을 추가하여 `pgvector` 확장을 활성화합니다.
+아직 활성화되지 않은 경우, 새로 생성된 마이그레이션에 다음 줄을 추가하여 `pgvector` 확장 플러그인을 활성화합니다.
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS vector;

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/supabase.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/supabase.mdx
@@ -1,24 +1,24 @@
 # Supabase
 
-Langchain supports using Supabase Postgres database as a vector store, using the `pgvector` postgres extension. Refer to the [Supabase blog post](https://supabase.com/blog/openai-embeddings-postgres-vector) for more information.
+Langchain은 postgres의 확장인 `pgvector` 를 사용하여 Supabase Postgres database 를 VectorStore로 사용할 수 있도록 지원합니다. 자세한 내용은 [Supabase blog post](https://supabase.com/blog/openai-embeddings-postgres-vector)를 참고하세요.
 
-## Setup
+## 설치
 
-### Install the library with
+### 다음 명령어로 라이브러리를 설치합니다.
 
 ```bash npm2yarn
 npm install -S @supabase/supabase-js
 ```
 
-### Create a table and search function in your database
+### 데이터베이스에 테이블 및 검색 기능 만들기
 
-Run this in your database:
+데이터베이스에서 이것을 실행합니다.
 
 ```sql
--- Enable the pgvector extension to work with embedding vectors
+-- 임베딩 벡터와 함께 작동하도록 pgvector 확장을 활성화합니다.
 create extension vector;
 
--- Create a table to store your documents
+-- 문서를 저장할 테이블을 생성합니다.
 create table documents (
   id bigserial primary key,
   content text, -- corresponds to Document.pageContent
@@ -26,7 +26,7 @@ create table documents (
   embedding vector(1536) -- 1536 works for OpenAI embeddings, change if needed
 );
 
--- Create a function to search for documents
+-- 문서를 검색하는 함수를 생성합니다.
 create function match_documents (
   query_embedding vector(1536),
   match_count int
@@ -53,7 +53,7 @@ end;
 $$;
 ```
 
-## Usage
+## 사용
 
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/indexes/vector_stores/supabase.ts";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/weaviate.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/weaviate.mdx
@@ -6,9 +6,9 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Weaviate
 
-Weaviate는 객체와 벡터를 모두 저장하는 오픈소스 벡터 데이터베이스로, 벡터 검색과 구조화된 필터링을 결합할 수 있습니다. LangChain은 Weaviate의 공식 타입스크립트 클라이언트인 [`weaviate-ts-client`](https://weaviate.io/developers/weaviate/client-libraries/typescript) 패키지를 통해 Weaviate에 연결합니다.
+Weaviate는 객체와 벡터를 모두 저장하는 오픈소스 벡터 데이터베이스로, 벡터를 검색하고 구조화된 필터링 기능을 적용할 수 있습니다. LangChain은 Weaviate의 공식 타입스크립트 클라이언트인 [`weaviate-ts-client`](https://weaviate.io/developers/weaviate/client-libraries/typescript) 패키지를 통해 Weaviate에 연결합니다.
 
-LangChain은 Weaviate에 직접 벡터를 삽입하고 주어진 벡터의 가장 가까운 이웃을 Weaviate에 쿼리하여 모든 LangChain 임베딩 통합을 Weaviate와 사용할 수 있도록 합니다.
+LangChain은 Weaviate에 직접 벡터를 삽입하고 주어진 벡터의 가장 가까운 값을 Weaviate에 쿼리하여 모든 LangChain 임베딩 통합을 Weaviate와 사용할 수 있도록 합니다.
 
 ## 설치
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/weaviate.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/vector_stores/integrations/weaviate.mdx
@@ -6,25 +6,25 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Weaviate
 
-Weaviate is an open source vector database that stores both objects and vectors, allowing for combining vector search with structured filtering. LangChain connects to Weaviate via the `weaviate-ts-client` package, the official Typescript client for Weaviate.
+Weaviate는 객체와 벡터를 모두 저장하는 오픈소스 벡터 데이터베이스로, 벡터 검색과 구조화된 필터링을 결합할 수 있습니다. LangChain은 Weaviate의 공식 타입스크립트 클라이언트인 [`weaviate-ts-client`](https://weaviate.io/developers/weaviate/client-libraries/typescript) 패키지를 통해 Weaviate에 연결합니다.
 
-LangChain inserts vectors directly to Weaviate, and queries Weaviate for the nearest neighbors of a given vector, so that you can use all the LangChain Embeddings integrations with Weaviate.
+LangChain은 Weaviate에 직접 벡터를 삽입하고 주어진 벡터의 가장 가까운 이웃을 Weaviate에 쿼리하여 모든 LangChain 임베딩 통합을 Weaviate와 사용할 수 있도록 합니다.
 
-## Setup
+## 설치
 
 ```bash npm2yarn
 npm install weaviate-ts-client graphql
 ```
 
-You'll need to run Weaviate either locally or on a server, see [the Weaviate documentation](https://weaviate.io/developers/weaviate/installation) for more information.
+로컬 또는 서버에서 Weaviate를 실행해야 하며, 자세한 내용은 [Weaviate 문서](https://weaviate.io/developers/weaviate/installation)를 참조하세요.
 
-## Usage, insert documents
+## documents 삽입하기
 
 import InsertExample from "@examples/indexes/vector_stores/weaviate_fromTexts.ts";
 
 <CodeBlock language="typescript">{InsertExample}</CodeBlock>
 
-## Usage, query documents
+## documents 쿼리하기
 
 import QueryExample from "@examples/indexes/vector_stores/weaviate_search.ts";
 


### PR DESCRIPTION
Translate the vector store section in the indexes page into Korean
- /ko/docs/modules/indexes/vector_stores/
- /ko/docs/modules/indexes/vector_stores/integrations/
- /ko/docs/modules/indexes/vector_stores/integrations/memory
- /ko/docs/modules/indexes/vector_stores/integrations/hnswlib
- /ko/docs/modules/indexes/vector_stores/integrations/milvus
- /ko/docs/modules/indexes/vector_stores/integrations/opensearch
- /ko/docs/modules/indexes/vector_stores/integrations/memory
- /ko/docs/modules/indexes/vector_stores/integrations/pinecone
- /ko/docs/modules/indexes/vector_stores/integrations/prisma
- /ko/docs/modules/indexes/vector_stores/integrations/supabase
- /ko/docs/modules/indexes/vector_stores/integrations/weaviate