### PR TITLE
Translate the text_splitters docs into Korean

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/character.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/character.mdx
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # CharacterTextSplitter
 
-Besides the `RecursiveCharacterTextSplitter`, there is also the more standard `CharacterTextSplitter`. This splits only on one type of character (defaults to `"\n\n"`). You can use it in the exact same way.
+`RecursiveCharacterTextSplitter` 이외에 더 표준적인 `CharacterTextSplitter` 도 있습니다. 이 Splitter 는 오직 한가지의 문자만을 분할합니다. (defaut 값은 `"\n\n"` 입니다.) `CharacterTextSplitter` 는 `RecursiveCharacterTextSplitter` 와 똑같은 방식으로 사용하실 수 있습니다.
 
 ```typescript
 import { Document } from "langchain/document";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/markdown.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/markdown.mdx
@@ -4,7 +4,7 @@ hide_table_of_contents: true
 
 # `MarkdownTextSplitter`
 
-If your content is in Markdown format then `MarkdownTextSplitter`. This class will split your content into documents based on the Markdown headers. For example, if you have the following Markdown content:
+만약 당신의 내용이 마크다운 컨텐츠로 되어 있다면 `MarkdownTextSplitter`, 이 클래스를 이용하여 작성한 콘텐츠를 마크다운 헤더에 기반하여 나눌수 있습니다. 예를 들어, 아래와 같은 형태를 가지고 있을 경우를 뜻합니다.
 
 ```markdown
 # Header 1
@@ -20,7 +20,7 @@ This is some more content.
 This is even more content.
 ```
 
-Then the `MarkdownTextSplitter` will split the content into three documents:
+`MarkdownTextSplitter` 는 컨텐츠를 3개의 문서로 분할합니다.
 
 ```typescript
 import { MarkdownTextSplitter } from "langchain/text_splitter";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/recursive_character.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/recursive_character.mdx
@@ -4,9 +4,9 @@ hide_table_of_contents: true
 
 # `RecursiveCharacterTextSplitter`
 
-The recommended TextSplitter is the `RecursiveCharacterTextSplitter`. This will split documents recursively by different characters - starting with `"\n\n"`, then `"\n"`, then `" "`. This is nice because it will try to keep all the semantically relevant content in the same place for as long as possible.
+권장되는 `TextSplitter` 는 `RecursiveCharacterTextSplitter` 입니다. 이 클래스는 `"\n\n"` 으로 시작해, `"\n"`, `" "` 순으로 다른 문자들로 재귀적으로 문서를 분할합니다. 이 기능은 가능한 의미론적으로 관련된 모든 콘텐츠를 같은 장소에 두려고 하기 때문에 좋습니다.
 
-Important parameters to know here are `chunkSize` and `chunkOverlap`. `chunkSize` controls the max size (in terms of number of characters) of the final documents. `chunkOverlap` specifies how much overlap there should be between chunks. This is often helpful to make sure that the text isn't split weirdly. In the example below we set these values to be small (for illustration purposes), but in practice they default to `4000` and `200` respectively.
+여기서 알아야 하는 중요한 파라미터들은 `chunkSize` 와 `chunkOverlap` 입니다. `chunkSize` 는 최종 문서의 최대 사이즈(문자의 개수)를 조정합니다. `chunkOverlap` 은 chunk 사이에 얼마나 겹치는지를 정의합니다. 이 기능은 종종 텍스트가 이상하게 분할되지 않았음을 보장하는데 도움을 줍니다. 아래 예시에서 우리는 각각의 값을 작게 설정했습니다. 하지만 실제로 기본값은 각각 `4000` 그리고 `200` 입니다.
 
 ```typescript
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
@@ -22,7 +22,7 @@ const splitter = new RecursiveCharacterTextSplitter({
 const output = await splitter.createDocuments([text]);
 ```
 
-You'll note that in the above example we are splitting a raw text string and getting back a list of documents. We can also split documents directly.
+위의 예시에서 우리는 텍스트 문자열을 분할하고 문서의 리스트를 받는 것을 알 수 있습니다. 우리는 또한 문서를 직접 분할할 수도 있습니다.
 
 ```typescript
 import { Document } from "langchain/document";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/token.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/examples/token.mdx
@@ -4,15 +4,15 @@ hide_table_of_contents: true
 
 # TokenTextSplitter
 
-Finally, `TokenTextSplitter` splits a raw text string by first converting the text into BPE tokens, then split these tokens into chunks and convert the tokens within a single chunk back into text.
+마지막으로, `TokenTextSplitter` 는 텍스트를 BPE 토큰으로 변환한뒤 분할합니다. 그런 다음 이러한 토큰을 청크로 분할하고 단일 청크 내의 토큰을 다시 텍스트로 변환합니다.
 
-To utilize the `TokenTextSplitter`, first install the accompanying required library
+`TokenTextSplitter` 를 사용하기 위해서는 수반되는 라이브러리를 설치하여야 합니다.
 
 ```bash npm2yarn
 npm install -S @dqbd/tiktoken
 ```
 
-Then, you can use it like so:
+그 이후, 다음과 같이 사용할 수 있습니다.
 
 ```typescript
 import { Document } from "langchain/document";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/indexes/text_splitters/index.mdx
@@ -6,15 +6,15 @@ sidebar_position: 2
 
 import DocCardList from "@theme/DocCardList";
 
-# Getting Started: Text Splitters
+# Text Splitters 시작하기
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/indexing/text-splitters)
 :::
 
-Language Models are often limited by the amount of text that you can pass to them. Therefore, it is neccessary to split them up into smaller chunks. LangChain provides several utilities for doing so.
+언어 모델은 우리가 API 를 통해 넘길수 있는 문자의 양을 주로 제한합니다. 그러므로, 우리는 이를 작은 청크로 나누는 것이 필요합니다. LangChain 은 이를 위한 몇가지 유틸리티를 제공합니다.
 
-Using a Text Splitter can also help improve the results from vector store searches, as eg. smaller chunks may sometimes be more likely to match a query. Testing different chunk sizes (and chunk overlap) is a worthwhile exercise to tailor the results to your use case.
+Text Splitter 를 사용하는 것은 또한 벡터 스토어 검색 결과를 향상시킬 수 있습니다. 예를 들어, 더 작은 청크는 쿼리와 일치할 가능성이 더 높을 수 있습니다. 다른 청크 크기 (및 청크 오버랩)를 테스트하는 것은 사용 사례에 맞게 결과를 맞춤화하는 데 도움이되는 유용한 연습입니다.
 
 ```typescript
 interface TextSplitter {
@@ -31,7 +31,7 @@ interface TextSplitter {
 }
 ```
 
-Text Splitters expose two methods, `createDocuments` and `splitDocuments`. The former takes a list of raw text strings and returns a list of documents. The latter takes a list of documents and returns a list of documents. The difference is that `createDocuments` will split the raw text strings into chunks, while `splitDocuments` will split the documents into chunks.
+Text Splitters 는 두가지 메소드를 노출합니다. `createDocuments` 와 `splitDocuments` 입니다. 전자는 원시 텍스트 문자열의 목록을 가져 와서 문서의 목록을 반환합니다. 후자는 문서의 목록을 가져 와서 문서의 목록을 반환합니다. 차이점은 `createDocuments` 는 원시 텍스트 문자열을 청크로 분할하고, `splitDocuments` 는 문서를 청크로 분할합니다.
 
 ## All Text Splitters
 
@@ -39,7 +39,7 @@ Text Splitters expose two methods, `createDocuments` and `splitDocuments`. The f
 
 ## Advanced
 
-If you want to implement your own custom Text Splitter, you only need to subclass TextSplitter and implement a single method `splitText`. The method takes a string and returns a list of strings. The returned strings will be used as the chunks.
+만약 당신만의 Text Splitter 를 구현하기를 원한다면, 당신은 TextSplitter 를 서브클래스로 만들고, `splitText` 라는 단일 메소드를 구현하면 됩니다. 이 메소드는 문자열을 가져와서 문자열의 목록을 반환합니다. 반환된 문자열은 청크로 사용됩니다.
 
 ```typescript
 abstract class TextSplitter {


### PR DESCRIPTION
Translate the text_splitters docs into Korean
- /ko/docs/modules/indexes/text_splitters/index.mdx
- /ko/docs/modules/indexes/text_splitters/examples/character.mdx
- /ko/docs/modules/indexes/text_splitters/examples/markdown.mdx
- /ko/docs/modules/indexes/text_splitters/examples/recursive_character.mdx
- /ko/docs/modules/indexes/text_splitters/examples/token.mdx
