### PR TITLE
Translate memory to Korean

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_memory.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_memory.md
@@ -1,6 +1,6 @@
 # Buffer Memory
 
-BufferMemory is the simplest type of memory - it just remembers previous conversational back and forths directly.
+BufferMemory는 가장 단순한 타입의 memory로, 이전 대화 내용을 바로 기억합니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
@@ -27,8 +27,8 @@ console.log({ res2 });
 {response: ' You said your name is Jim. Is there anything else you would like to talk about?'}
 ```
 
-You can also load messages into a `BufferMemory` instance by creating and passing in a `ChatHistory` object.
-This lets you easily pick up state from past conversations:
+또한 `ChatHistory` 객체를 생성하고 전달하여 `BufferMemory` 객체에 메시지를 로드할 수도 있습니다.
+메시지를 로드하면서 과거 대화에서 메시지를 쉽게 가져올 수 있습니다:
 
 ```typescript
 import { ChatMessageHistory } from "langchain/memory";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_memory_chat.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_memory_chat.mdx
@@ -7,7 +7,6 @@ import Example from "@examples/chat/memory.ts";
 
 # Using Buffer Memory with Chat Models
 
-This example covers how to use chat-specific memory classes with chat models.
-The key thing to notice is that setting `returnMessages: true` makes the memory return a list of chat messages instead of a string.
+이 예시에서는 chat model에 대화 전용 memory 클래스를 사용하는 방법을 살펴봅니다. 중요한 점은 returnMessages: true를 설정하면 메모리가 문자열 대신 대화 목록을 반환한다는 점입니다.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_window_memory.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/buffer_window_memory.md
@@ -1,6 +1,6 @@
 # Buffer Window Memory
 
-BufferWindowMemory keeps track of the back-and-forths in conversation, and then uses a window of size `k` to surface the last `k` back-and-forths to use as memory.
+BufferWindowMemory는 대화의 앞뒤를 추적한 다음 `k` 크기의 window를 사용하여 memory로 사용할 마지막 `k`의 앞뒤를 표시합니다.
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/conversation_summary.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/conversation_summary.mdx
@@ -7,15 +7,15 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Conversation Summary Memory
 
-The Conversation Summary Memory summarizes the conversation as it happens and stores the current summary in memory. This memory can then be used to inject the summary of the conversation so far into a prompt/chain. This memory is most useful for longer conversations, where keeping the past message history in the prompt verbatim would take up too many tokens.
+Conversation Summary Memory는 대화가 진행되는 동안 대화를 요약하고 현재 요약을 메모리에 저장합니다. 그런 다음 이 메모리를 사용하여 지금까지의 대화 요약을 prompt/chain에 주입할 수 있습니다. 이 메모리는 과거 메시지 기록을 prompt에 그대로 보관하면 토큰을 너무 많이 차지할 수 있는 긴 대화에 가장 유용합니다.
 
-## Usage, with an LLM
+## LLM과 사용
 
 import TextExample from "@examples/memory/summary_llm.ts";
 
 <CodeBlock language="typescript">{TextExample}</CodeBlock>
 
-## Usage, with a Chat Model
+## Chat Model과 사용
 
 import ChatExample from "@examples/memory/summary_chat.ts";
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/index.mdx
@@ -4,6 +4,6 @@ sidebar_label: Examples
 
 import DocCardList from "@theme/DocCardList";
 
-# Examples: Memory
+# 예시: Memory
 
 <DocCardList />

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/motorhead_memory.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/examples/motorhead_memory.md
@@ -1,12 +1,12 @@
 # Motörhead Memory
 
-[Motörhead](https://github.com/getmetal/motorhead) is a memory server implemented in Rust. It automatically handles incremental summarization in the background and allows for stateless applications.
+[Motörhead](https://github.com/getmetal/motorhead)는 Rust로 구현된 memory 서버입니다. 백그라운드에서 점진적 요약을 자동으로 처리하고 stateless 애플리케이션을 지원합니다.
 
-## Setup
+## 준비
 
-See instructions at [Motörhead](https://github.com/getmetal/motorhead) for running the server locally.
+로컬에서 서버를 실행하려면 [Motörhead](https://github.com/getmetal/motorhead)의 설명을 참고하세요.
 
-## Usage
+## 사용 방법
 
 ```typescript
 import { ConversationChain } from "langchain/chains";

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/index.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/memory/index.mdx
@@ -5,13 +5,13 @@ sidebar_position: 5
 
 import DocCardList from "@theme/DocCardList";
 
-# Getting Started: Memory
+# 시작하기: Memory
 
 :::info
 [Conceptual Guide](https://docs.langchain.com/docs/components/memory)
 :::
 
-Memory is the concept of storing and retrieving data in the process of a conversation. There are two main methods, `loadMemoryVariables` and `saveContext`. The first method is used to retrieve data from memory (optionally using the current input values), and the second method is used to store data in memory.
+Memory는 대화 과정에서 데이터를 저장하고 검색하는 개념입니다. `loadMemoryVariables`와 `saveContext`의 두 가지 메인 메소드가 있습니다. 첫 번째 메소드는 memory에서 데이터를 검색하는 데 사용되며(선택적으로 현재 입력 값을 사용), 두 번째 메소드는 memory에 데이터를 저장하는 데 사용됩니다.
 
 ```typescript
 export type InputValues = Record<string, any>;
@@ -29,24 +29,24 @@ interface BaseMemory {
 ```
 
 :::note
-Do not share the same memory instance between two different chains, a memory instance represents the history of a single conversation
+서로 다른 두 chain 간에 동일한 memory 객체를 공유하지 마세요. memory 객체는 단일 대화의 기록을 나타냅니다.
 :::
 
 :::note
-If you deploy your LangChain app on a serverless environment do not store memory instances in a variable, as your hosting provider may have reset it by the next time the function is called.
+서버리스 환경에 LangChain 앱을 배포하는 경우 다음에 함수를 호출할 때 호스팅 제공업체가 memory 객체를 재설정했을 수 있으므로 변수에 memory 객체를 저장하지 마세요.
 :::
 
-## All Memory classes
+## 모든 Memory classes
 
 <DocCardList />
 
-## Advanced
+## 심화
 
-To implement your own memory class you have two options:
+고유한 memory 클래스를 구현하려면 두 가지 옵션이 있습니다:
 
-### Subclassing `BaseChatMemory`
+### `BaseChatMemory` 서브클래스화
 
-This is the easiest way to implement your own memory class. You can subclass `BaseChatMemory`, which takes care of `saveContext` by saving inputs and outputs as [Chat Messages](../schema/chat-messages.md), and implement only the `loadMemoryVariables` method. This method is responsible for returning the memory variables that are relevant for the current input values.
+`BaseChatMemory` 서브클래스화는 고유 memory 클래스를 구현하는 가장 쉬운 방법입니다. 입력과 출력을 [Chat Messages](../schema/chat-messages.md)로 저장하여 `saveContext`를 처리하는 `BaseChatMemory`를 서브클래스화하고, `loadMemoryVariables` 메소드만 구현하면 됩니다.`loadMemoryVariables` 메소드는 현재 입력 값과 관련된 메모리 변수를 반환하는 역할을 합니다.
 
 ```typescript
 abstract class BaseChatMemory extends BaseMemory {
@@ -56,9 +56,9 @@ abstract class BaseChatMemory extends BaseMemory {
 }
 ```
 
-### Subclassing `BaseMemory`
+### `BaseMemory` 서브클래스화
 
-If you want to implement a more custom memory class, you can subclass `BaseMemory` and implement both `loadMemoryVariables` and `saveContext` methods. The `saveContext` method is responsible for storing the input and output values in memory. The `loadMemoryVariables` method is responsible for returning the memory variables that are relevant for the current input values.
+더 맞춤화된 memory 클래스를 구현하려면 `BaseMemory`를 서브 클래스화하고 `loadMemoryVariables`와 `saveContext` 메소드를 모두 구현하면 됩니다. `saveContext` 메소드는 입력 및 출력 값을 memory에 저장하는 역할을 합니다. `loadMemoryVariables` 메소드는 현재 입력 값과 관련된 메모리 변수를 반환하는 역할을 합니다.
 
 ```typescript
 abstract class BaseMemory {


### PR DESCRIPTION
- Translate `memory/examples/buffer_memory_chat`
- Translate `memory/examples/buffer_memory`
- Translate `memory/examples/buffer_window_memory`
- Translate `memory/examples/conversation_summary`
- Translate `memory/examples/index`
- Translate `memory/examples/motorhead_memory`
- Translate `memory/index`

memory라는 용어를 메모리로 번역하는게 더 친숙할지 조금 고민되어 일단 memory로 해석하지 않고 사용했습니다.